### PR TITLE
Add overview page for regional powers

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
       <h2>Data & Records</h2>
       <ul>
         <li><a href="powers.html">Great Powers – Armies, Navies & Evolution</a></li>
+        <li><a href="powers_military.html">Great Powers & Their Militaries</a></li>
         <li><a href="armies.html">Armies of Samogitia</a></li>
         <li><a href="navies.html">Royal Navy</a></li>
         <li><a href="rulers.html">Rulers & Advisors</a></li>

--- a/powers_military.html
+++ b/powers_military.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Great Powers & Their Militaries</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root {
+      --ink: #222;
+      --muted: #666;
+      --accent: #8b0000;
+      --card: #fff;
+      --bg: #f7f7f7;
+      --line: #e6e6e6;
+    }
+    html,body { margin: 0; background: var(--bg); color: var(--ink); font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    .banner { background: linear-gradient(90deg,var(--accent),#b22222); color: #fff; text-align: center; padding: 2rem 1rem; }
+    .banner h1 { margin: 0; font-family: Georgia, serif; font-size: 2rem; }
+    .banner p { margin: .4rem 0 0; color: #f0f0f0; }
+    .container { max-width: 1000px; margin: 2rem auto; padding: 0 1rem; }
+    table { width: 100%; border-collapse: collapse; font-size: .95rem; background: #fcfcfc; border: 1px solid var(--line); border-radius: .4rem; overflow: hidden; }
+    th, td { padding: .5rem .6rem; border-bottom: 1px solid var(--line); }
+    th { background: #f2e6e6; color: #4b0000; text-align: left; }
+    tr:last-child td { border-bottom: 0; }
+    .back { display: inline-block; margin: 1.5rem 0 0; text-decoration: none; color: var(--accent); font-weight: 700; }
+    .back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <header class="banner">
+    <h1>Great Powers & Their Militaries</h1>
+    <p>Standing armies and navies at the dawn of 1444</p>
+  </header>
+
+  <main class="container">
+    <table>
+      <thead>
+        <tr>
+          <th>Power</th>
+          <th>Army</th>
+          <th>Navy</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Teutonic Order</td>
+          <td>12,000 (9,000 Infantry · 3,000 Cavalry)</td>
+          <td>2 Heavy · 6 Light · 4 Galleys · 3 Transports</td>
+        </tr>
+        <tr>
+          <td>Livonian Order</td>
+          <td>10,000 (7,000 Infantry · 3,000 Cavalry)</td>
+          <td>0 Heavy · 3 Light · 6 Galleys · 2 Transports</td>
+        </tr>
+        <tr>
+          <td>Poland</td>
+          <td>25,000 (18,000 Infantry · 7,000 Cavalry)</td>
+          <td>0 Heavy · 9 Light · 0 Galleys · 10 Transports</td>
+        </tr>
+        <tr>
+          <td>Lithuania</td>
+          <td>32,000 (24,000 Infantry · 8,000 Cavalry)</td>
+          <td>No standing navy</td>
+        </tr>
+        <tr>
+          <td>Muscovy</td>
+          <td>30,000 (24,000 Infantry · 6,000 Cavalry)</td>
+          <td>0 Heavy · 0 Light · 0 Galleys · 5 Transports</td>
+        </tr>
+        <tr>
+          <td>Denmark</td>
+          <td>18,000 (12,000 Infantry · 6,000 Cavalry)</td>
+          <td>10 Heavy · 12 Light · 0 Galleys · 15 Transports</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <a class="back" href="index.html">← Back to Chronicle Index</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone page listing major regional powers and their armies/navies
- Link new powers overview from site index

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa341d4dd0832e9afc658a41e67598