### PR TITLE
refactor: centralize shared styles

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -14,17 +14,6 @@
   </div>
 </nav>
 
-<style>
-.site-nav{position:sticky; top:0; z-index:999; background:#fff; border-bottom:1px solid #e6e6e6}
-.site-nav .nav-wrap{max-width:1200px; margin:0 auto; padding:.6rem 1rem; display:flex; align-items:center; gap:1rem}
-.site-nav .brand{font-weight:800; text-decoration:none; color:#8b0000; letter-spacing:.2px}
-.site-nav .links{list-style:none; margin:0; padding:0; display:flex; gap:.8rem; flex-wrap:wrap}
-.site-nav .links a{display:block; padding:.35rem .6rem; text-decoration:none; color:#333; border-radius:.45rem}
-.site-nav .links a:hover{background:#f6f6f6}
-.site-nav .links a.active{background:#8b0000; color:#fff}
-@media (max-width:720px){ .site-nav .links{gap:.4rem} }
-</style>
-
 <script>
   // Highlight the active link
   (function(){

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,95 @@
+:root{
+  --ink:#222;
+  --muted:#666;
+  --accent:#8b0000;
+  --card:#fff;
+  --bg:#f7f7f7;
+  --line:#e6e6e6;
+}
+html,body{
+  margin:0;
+  background:var(--bg);
+  color:var(--ink);
+  font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
+  line-height:1.6;
+}
+.banner{
+  background:linear-gradient(90deg,var(--accent),#b22222);
+  color:#fff;
+  text-align:center;
+  padding:2rem 1rem;
+}
+.banner h1{
+  margin:0;
+  font-family:Georgia,serif;
+  font-size:2rem;
+}
+.banner p{
+  margin:.4rem 0 0;
+  color:#f0f0f0;
+}
+.container{
+  max-width:1100px;
+  margin:2rem auto;
+  padding:0 1rem;
+}
+.card{
+  background:var(--card);
+  border:1px solid var(--line);
+  border-radius:.6rem;
+  box-shadow:0 1px 4px rgba(0,0,0,.05);
+  padding:1rem;
+}
+.card h2{
+  font-family:Georgia,serif;
+  color:var(--accent);
+  font-size:1.2rem;
+  margin:.2rem 0 1rem;
+}
+table{
+  width:100%;
+  border-collapse:collapse;
+  background:#fcfcfc;
+  border:1px solid var(--line);
+  border-radius:.4rem;
+  overflow:hidden;
+  font-size:.95rem;
+}
+th,td{
+  padding:.5rem .6rem;
+  border-bottom:1px solid var(--line);
+  text-align:left;
+}
+th{
+  background:#f2e6e6;
+  color:#4b0000;
+}
+tr:last-child td{
+  border-bottom:0;
+}
+.muted{color:var(--muted);font-size:.9rem;}
+.back{
+  display:inline-block;
+  margin:1.5rem 0 0;
+  text-decoration:none;
+  color:var(--accent);
+  font-weight:700;
+}
+.back:hover{text-decoration:underline;}
+canvas{
+  width:100%!important;
+  max-width:100%;
+  background:#fff;
+  border:1px solid var(--line);
+  border-radius:.4rem;
+}
+.site-nav{position:sticky;top:0;z-index:999;background:#fff;border-bottom:1px solid var(--line);}
+.site-nav .nav-wrap{max-width:1200px;margin:0 auto;padding:.6rem 1rem;display:flex;align-items:center;gap:1rem;}
+.site-nav .brand{font-weight:800;text-decoration:none;color:var(--accent);letter-spacing:.2px;}
+.site-nav .links{list-style:none;margin:0;padding:0;display:flex;gap:.8rem;flex-wrap:wrap;}
+.site-nav .links a{display:block;padding:.35rem .6rem;text-decoration:none;color:#333;border-radius:.45rem;}
+.site-nav .links a:hover{background:#f6f6f6;}
+.site-nav .links a.active{background:var(--accent);color:#fff;}
+@media (max-width:720px){.site-nav .links{gap:.4rem;}}
+
+h2{font-family:Georgia,serif;color:var(--accent);}

--- a/chapter1.html
+++ b/chapter1.html
@@ -4,65 +4,32 @@
   <meta charset="UTF-8" />
   <title>Chapter I – The Dawn of Samogitia (1444)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="assets/css/styles.css">
   <style>
-    :root{
-      --ink:#222; --muted:#666; --accent:#8b0000;
-      --card:#ffffff; --bg:#f7f7f7; --line:#e6e6e6;
-    }
-    html,body{margin:0;background:var(--bg);color:var(--ink);font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.6}
-
-    /* Banner */
-    .banner{background:linear-gradient(90deg,var(--accent),#b22222);color:#fff;text-align:center;padding:2rem 1rem}
-    .banner h1{margin:0;font-family:Georgia,serif;font-size:2rem}
-    .banner p{margin:.4rem 0 0;font-style:italic;color:#f2f2f2}
-
-    /* Layout */
-    .container{max-width:1100px;margin:2rem auto;padding:0 1rem}
-    .layout{display:grid;grid-template-columns:2fr 1fr;gap:1.25rem}
-    @media (max-width: 900px){.layout{grid-template-columns:1fr}}
-
-    .card{background:var(--card);border:1px solid var(--line);border-radius:.6rem;box-shadow:0 1px 4px rgba(0,0,0,.05);padding:1rem}
-    .card h2{font-family:Georgia,serif;font-size:1.15rem;color:var(--accent);margin:0 0 .75rem}
-    .card p{margin:.6rem 0}
-
-    /* Facts grid */
-    .facts{display:grid;grid-template-columns:1fr 1fr;gap:.4rem .8rem;font-size:.95rem}
-    .facts dt{color:var(--muted)}
-    .facts dd{margin:0;font-weight:600}
-    @media (max-width: 640px){.facts{grid-template-columns:1fr}}
-
-    /* Table */
-    table{width:100%;border-collapse:collapse;font-size:.95rem;background:#fcfcfc;border:1px solid var(--line);border-radius:.4rem;overflow:hidden}
-    th,td{padding:.5rem .6rem;border-bottom:1px solid var(--line)}
-    th{background:#f2e6e6;color:#4b0000;text-align:left;font-weight:700}
-    tr:last-child td{border-bottom:0}
-
-    /* Chips / labels */
-    .chips{display:flex;flex-wrap:wrap;gap:.4rem;margin:.5rem 0}
-    .chip{border:1px solid var(--line);padding:.2rem .5rem;border-radius:999px;font-size:.85rem;background:#fff}
-    .chip--danger{background:#fde7e7;border-color:#f3c9c9;color:#680000}
-
-    /* Sidebar */
-    .sidebar{position:sticky;top:1rem;align-self:start}
-    .map{margin:0 0 .8rem}
-    .map a{display:block;text-decoration:none;color:inherit}
-    .map img{width:100%;height:auto;display:block;border-radius:.5rem;border:1px solid var(--line);box-shadow:0 1px 4px rgba(0,0,0,.06)}
-    .map small{display:block;margin-top:.35rem;color:var(--muted)}
-
-    /* TOC */
-    .toc{list-style:none;margin:0;padding:0}
-    .toc li{margin:.25rem 0}
-    .toc a{text-decoration:none;color:#333}
-    .toc a:hover{text-decoration:underline}
-
-    /* Timeline list */
-    .timeline{list-style:none;padding:0;margin:0}
-    .timeline li{padding:.5rem .6rem;border-left:3px solid #e6e6e6;margin:.4rem 0 .4rem .3rem}
-    .timeline time{font-weight:700;color:#4b0000;margin-right:.4rem}
-
-    /* Back link */
-    .back{display:inline-block;margin:1rem 0 0;text-decoration:none;color:var(--accent);font-weight:700}
-    .back:hover{text-decoration:underline}
+    /* Page-specific styles for Chapter I */
+    .layout{display:grid;grid-template-columns:2fr 1fr;gap:1.25rem;}
+    @media (max-width:900px){.layout{grid-template-columns:1fr;}}
+    .card h2{font-size:1.15rem;margin:0 0 .75rem;}
+    .card p{margin:.6rem 0;}
+    .facts{display:grid;grid-template-columns:1fr 1fr;gap:.4rem .8rem;font-size:.95rem;}
+    .facts dt{color:var(--muted);}
+    .facts dd{margin:0;font-weight:600;}
+    @media (max-width:640px){.facts{grid-template-columns:1fr;}}
+    .chips{display:flex;flex-wrap:wrap;gap:.4rem;margin:.5rem 0;}
+    .chip{border:1px solid var(--line);padding:.2rem .5rem;border-radius:999px;font-size:.85rem;background:#fff;}
+    .chip--danger{background:#fde7e7;border-color:#f3c9c9;color:#680000;}
+    .sidebar{position:sticky;top:1rem;align-self:start;}
+    .map{margin:0 0 .8rem;}
+    .map a{display:block;text-decoration:none;color:inherit;}
+    .map img{width:100%;height:auto;display:block;border-radius:.5rem;border:1px solid var(--line);box-shadow:0 1px 4px rgba(0,0,0,.06);}
+    .map small{display:block;margin-top:.35rem;color:var(--muted);}
+    .toc{list-style:none;margin:0;padding:0;}
+    .toc li{margin:.25rem 0;}
+    .toc a{text-decoration:none;color:#333;}
+    .toc a:hover{text-decoration:underline;}
+    .timeline{list-style:none;padding:0;margin:0;}
+    .timeline li{padding:.5rem .6rem;border-left:3px solid #e6e6e6;margin:.4rem 0 .4rem .3rem;}
+    .timeline time{font-weight:700;color:#4b0000;margin-right:.4rem;}
   </style>
 </head>
 <body>

--- a/chapter2.html
+++ b/chapter2.html
@@ -5,47 +5,31 @@
   <title>Chapter II — Expansion & The First War (1445–1446) | Chronicle of Samogitia</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Chapter II details Samogitia’s early expansion and pre-war build-up, including the Iron Wolf and Black Death armies, and succession events in 1446." />
+  <link rel="stylesheet" href="assets/css/styles.css">
   <style>
-    :root{
-      --ink:#222; --muted:#666; --accent:#8b0000; --card:#fff; --bg:#f7f7f7; --line:#e6e6e6;
-    }
-    html,body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";line-height:1.6}
-    /* Top nav (client-include fallback) */
-    nav#site-nav{background:#fff;border-bottom:1px solid var(--line)}
-    nav#site-nav .fallback{display:flex;flex-wrap:wrap;gap:.8rem;padding:.6rem 1rem;list-style:none;margin:0}
-    nav#site-nav .fallback a{color:#333;text-decoration:none;padding:.2rem .45rem;border-radius:8px}
-    nav#site-nav .fallback a[aria-current="page"]{background:#f4eaea}
-    nav#site-nav .fallback a:hover{background:#f0f0f0}
-    /* Banner */
-    .banner{background:linear-gradient(90deg,var(--accent),#b22222);color:#fff;text-align:center;padding:2.4rem 1rem}
-    .banner h1{margin:0;font-size:clamp(1.6rem,2vw+1rem,2.4rem);letter-spacing:.4px}
-    .banner p{margin:.4rem 0 0 0;opacity:.9}
-    /* Layout */
-    .wrap{max-width:1100px;margin:0 auto;padding:1.25rem}
-    main{display:grid;grid-template-columns:1fr 320px;gap:1.25rem}
-    @media (max-width: 980px){ main{grid-template-columns:1fr} }
-    /* Cards */
-    .card{background:var(--card);border:1px solid var(--line);border-radius:14px;box-shadow:0 1px 2px rgba(0,0,0,.04);padding:1rem}
-    .card h2,.card h3{margin:.1rem 0 .6rem 0}
-    .kicker{font-size:.9rem;letter-spacing:.05em;text-transform:uppercase;color:#b94c4c}
-    .muted{color:var(--muted)}
-    /* Timeline */
-    .timeline{border-left:3px solid var(--line);margin-left:.4rem;padding-left:1rem}
-    .event{margin:1rem 0}
-    .event time{font-weight:600}
-    /* Definition lists */
-    dl{display:grid;grid-template-columns:auto 1fr;gap:.4rem .8rem;margin:.6rem 0}
-    dt{color:var(--muted)}
-    dd{margin:0}
-    /* Tables */
-    table{width:100%;border-collapse:collapse}
-    th,td{padding:.5rem;border-bottom:1px solid var(--line);text-align:left}
-    th{background:#faf7f7}
-    /* Badges */
-    .badge{display:inline-block;font-size:.8rem;padding:.1rem .5rem;border:1px solid var(--line);border-radius:999px}
-    .ok{background:#edf7ed;border-color:#cfe7cf}
-    footer{color:var(--muted);font-size:.95rem;padding:2rem 0}
-    code.inline{background:#f3f3f3;border:1px solid #e5e5e5;padding:.05rem .35rem;border-radius:5px}
+    /* Page-specific styles for Chapter II */
+    nav#site-nav .fallback{display:flex;flex-wrap:wrap;gap:.8rem;padding:.6rem 1rem;list-style:none;margin:0;}
+    nav#site-nav .fallback a{color:#333;text-decoration:none;padding:.2rem .45rem;border-radius:8px;}
+    nav#site-nav .fallback a[aria-current="page"]{background:#f4eaea;}
+    nav#site-nav .fallback a:hover{background:#f0f0f0;}
+    .wrap{max-width:1100px;margin:0 auto;padding:1.25rem;}
+    main{display:grid;grid-template-columns:1fr 320px;gap:1.25rem;}
+    @media (max-width:980px){main{grid-template-columns:1fr;}}
+    .card h2,.card h3{margin:.1rem 0 .6rem 0;}
+    .kicker{font-size:.9rem;letter-spacing:.05em;text-transform:uppercase;color:#b94c4c;}
+    .timeline{border-left:3px solid var(--line);margin-left:.4rem;padding-left:1rem;}
+    .event{margin:1rem 0;}
+    .event time{font-weight:600;}
+    dl{display:grid;grid-template-columns:auto 1fr;gap:.4rem .8rem;margin:.6rem 0;}
+    dt{color:var(--muted);}
+    dd{margin:0;}
+    table{width:100%;border-collapse:collapse;}
+    th,td{padding:.5rem;border-bottom:1px solid var(--line);text-align:left;}
+    th{background:#faf7f7;}
+    .badge{display:inline-block;font-size:.8rem;padding:.1rem .5rem;border:1px solid var(--line);border-radius:999px;}
+    .ok{background:#edf7ed;border-color:#cfe7cf;}
+    footer{color:var(--muted);font-size:.95rem;padding:2rem 0;}
+    code.inline{background:#f3f3f3;border:1px solid #e5e5e5;padding:.05rem .35rem;border-radius:5px;}
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -3,69 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <title>The Chronicle of Samogitia</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
   <style>
-    body {
-      margin: 0;
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-      background: #f9f9f9;
-      color: #222;
-      line-height: 1.7;
-    }
-    .banner {
-      background: linear-gradient(to right, #8b0000, #b22222);
-      color: white;
-      padding: 3em 1em;
-      text-align: center;
-    }
-    .banner h1 {
-      font-family: Georgia, serif;
-      font-size: 3em;
-      margin: 0;
-    }
-    .banner p {
-      font-size: 1.2em;
-      color: #f0f0f0;
-      margin-top: 0.5em;
-      font-style: italic;
-    }
-    .container {
-      max-width: 900px;
-      margin: 3em auto;
-      padding: 0 2em;
-    }
-    h2 {
-      font-family: Georgia, serif;
-      font-size: 1.5em;
-      margin-bottom: 0.8em;
-      color: #8b0000;
-    }
-    .section {
-      margin-bottom: 3em;
-    }
-    ul {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1em;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    a {
-      display: block;
-      padding: 1em;
-      border-radius: 8px;
-      background: #fff;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-      text-decoration: none;
-      color: #222;
-      font-weight: 500;
-      transition: all 0.2s ease;
-    }
-    a:hover {
-      background: #8b0000;
-      color: white;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    }
+    /* Page-specific styles for the index */
+    .container{max-width:900px;margin:3em auto;padding:0 2em;}
+    .section{margin-bottom:3em;}
+    h2{font-size:1.5em;margin-bottom:.8em;}
+    ul{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1em;list-style:none;padding:0;margin:0;}
+    a{display:block;padding:1em;border-radius:8px;background:#fff;box-shadow:0 2px 6px rgba(0,0,0,0.08);text-decoration:none;color:#222;font-weight:500;transition:all .2s ease;}
+    a:hover{background:var(--accent);color:#fff;box-shadow:0 4px 12px rgba(0,0,0,0.15);}
   </style>
 </head>
 <body>

--- a/nav.html
+++ b/nav.html
@@ -7,17 +7,8 @@
       <li><a href="samogitia.html">Samogitia Evolution</a></li>
     </ul>
   </div>
-</nav>
 
-<style>
-.site-nav{position:sticky; top:0; z-index:999; background:#fff; border-bottom:1px solid #e6e6e6}
-.site-nav .nav-wrap{max-width:1200px; margin:0 auto; padding:.6rem 1rem; display:flex; align-items:center; gap:1rem}
-.site-nav .brand{font-weight:800; text-decoration:none; color:#8b0000; letter-spacing:.2px}
-.site-nav .links{list-style:none; margin:0; padding:0; display:flex; gap:.8rem; flex-wrap:wrap}
-.site-nav .links a{display:block; padding:.35rem .6rem; text-decoration:none; color:#333; border-radius:.45rem}
-.site-nav .links a:hover{background:#f6f6f6}
-.site-nav .links a.active{background:#8b0000; color:#fff}
-</style>
+</nav>
 
 <script>
   // highlight active link

--- a/powers.html
+++ b/powers.html
@@ -4,37 +4,16 @@
   <meta charset="UTF-8">
   <title>Powers of 1444</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="assets/css/styles.css">
   <style>
-    :root{--ink:#222;--muted:#666;--accent:#8b0000;--card:#fff;--bg:#f7f7f7;--line:#e6e6e6}
-    html,body{margin:0;background:var(--bg);color:var(--ink);font-family:"Helvetica Neue",Arial,sans-serif;line-height:1.6}
-    .banner{background:linear-gradient(90deg,var(--accent),#b22222);color:#fff;text-align:center;padding:2rem 1rem}
-    .banner h1{margin:0;font-family:Georgia,serif;font-size:1.9rem}
-    .banner p{margin:.4rem 0 0;color:#f0f0f0}
-
-    .container{max-width:1200px;margin:2rem auto;padding:0 1rem}
-    .grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
-    @media(max-width:940px){.grid{grid-template-columns:1fr}}
-
-    .card{background:var(--card);border:1px solid var(--line);border-radius:.6rem;box-shadow:0 1px 4px rgba(0,0,0,.05);padding:1rem}
-    h2{font-family:Georgia,serif;color:var(--accent);font-size:1.2rem;margin:.2rem 0 1rem}
-
-    table{width:100%;border-collapse:collapse;background:#fcfcfc;border:1px solid var(--line);border-radius:.4rem;overflow:hidden;font-size:.95rem}
-    th,td{padding:.5rem .6rem;border-bottom:1px solid var(--line);text-align:left;white-space:nowrap}
-    th{background:#f2e6e6;color:#4b0000}
-    tr:last-child td{border-bottom:0}
-    .muted{color:var(--muted);font-size:.9rem}
-
-    canvas{width:100%!important;max-width:100%;height:480px!important;background:#fff;border:1px solid var(--line);border-radius:.4rem}
-    .back{display:inline-block;margin:1.5rem 0 0;text-decoration:none;color:var(--accent);font-weight:700}
-    .back:hover{text-decoration:underline}
-
-    /* toolbar */
-    .toolbar{display:flex;gap:.5rem;align-items:center;margin:.25rem 0 1rem}
-    .toolbar button{
-      border:1px solid var(--line);background:#fff;border-radius:.5rem;
-      padding:.45rem .8rem;cursor:pointer;font-weight:600
-    }
-    .toolbar button:hover{background:#f6f6f6}
+    /* Page-specific styles for Powers */
+    .container{max-width:1200px;}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem;}
+    @media(max-width:940px){.grid{grid-template-columns:1fr;}}
+    canvas{height:480px!important;}
+    .toolbar{display:flex;gap:.5rem;align-items:center;margin:.25rem 0 1rem;}
+    .toolbar button{border:1px solid var(--line);background:#fff;border-radius:.5rem;padding:.45rem .8rem;cursor:pointer;font-weight:600;}
+    .toolbar button:hover{background:#f6f6f6;}
   </style>
 </head>
 <body>

--- a/samogitia.html
+++ b/samogitia.html
@@ -4,30 +4,12 @@
   <meta charset="UTF-8">
   <title>Samogitia — Military & Navy Evolution</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="assets/css/styles.css">
   <style>
-    :root{
-      --ink:#222; --muted:#666; --accent:#8b0000;
-      --card:#fff; --bg:#f7f7f7; --line:#e6e6e6;
-    }
-    html,body{margin:0;background:var(--bg);color:var(--ink);
-      font-family:"Helvetica Neue",Arial,sans-serif;line-height:1.6}
-    .banner{background:linear-gradient(90deg,var(--accent),#b22222);
-      color:#fff;text-align:center;padding:2rem 1rem}
-    .banner h1{margin:0;font-family:Georgia,serif;font-size:2rem}
-    .banner p{margin:.4rem 0 0;color:#f0f0f0}
-    .container{max-width:1000px;margin:2rem auto;padding:0 1rem}
-    .card{background:var(--card);border:1px solid var(--line);
-      border-radius:.6rem;box-shadow:0 1px 4px rgba(0,0,0,.05);padding:1rem;margin-bottom:1.5rem}
-    h2{font-family:Georgia,serif;color:var(--accent);font-size:1.3rem;margin:.2rem 0 1rem}
-    table{width:100%;border-collapse:collapse;background:#fcfcfc;border:1px solid var(--line);
-      border-radius:.4rem;overflow:hidden;font-size:.95rem}
-    th,td{padding:.5rem .6rem;border-bottom:1px solid var(--line);text-align:left;white-space:nowrap}
-    th{background:#f2e6e6;color:#4b0000}
-    tr:last-child td{border-bottom:0}
-    .muted{color:var(--muted);font-size:.9rem}
-    .back{display:inline-block;margin:1.5rem 0 0;text-decoration:none;color:#f00; color:var(--accent);font-weight:700}
-    .back:hover{text-decoration:underline}
-    canvas{width:100%!important;max-width:100%;height:420px!important;background:#fff;border:1px solid var(--line);border-radius:.4rem}
+    /* Page-specific styles for Samogitia evolution */
+    .container{max-width:1000px;}
+    .card{margin-bottom:1.5rem;}
+    canvas{height:420px!important;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- consolidate repeated CSS into new `assets/css/styles.css`
- link global stylesheet from all pages and strip duplicated inline rules
- tidy navigation snippet to rely on shared styling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa42e16fac832e872d2c3a920b1b61