### PR TITLE
Fix chapter links in chapter2

### DIFF
--- a/chapter2.html
+++ b/chapter2.html
@@ -54,8 +54,8 @@
   <nav id="site-nav" data-src="/partials/nav.html">
     <ul class="fallback">
       <li><a href="index.html">Index</a></li>
-      <li><a href="chapter-1.html">Chapter I</a></li>
-      <li><a href="chapter-2.html" aria-current="page"><strong>Chapter II</strong></a></li>
+      <li><a href="chapter1.html">Chapter I</a></li>
+      <li><a href="chapter2.html" aria-current="page"><strong>Chapter II</strong></a></li>
       <li><a href="military-records.html">Military Records</a></li>
       <li><a href="military-graph.html">Military Graph</a></li>
       <li><a href="data.html">Data</a></li>
@@ -129,7 +129,7 @@
         <section class="card" style="margin-top:1rem">
           <h3>Cross-References</h3>
           <ul>
-            <li><a href="chapter-1.html">Chapter I — The Dawn of Samogitia</a></li>
+            <li><a href="chapter1.html">Chapter I — The Dawn of Samogitia</a></li>
             <li><a href="military-records.html">Military Records</a></li>
             <li><a href="military-graph.html">Military Graph</a></li>
             <li><a href="data.html">Data Appendix</a></li>
@@ -139,7 +139,7 @@
     </main>
 
     <footer class="wrap">
-      <p>Prev: <a href="chapter-1.html">Chapter I — The Dawn</a> · Next: <span class="muted">Chapter III (to be added)</span></p>
+      <p>Prev: <a href="chapter1.html">Chapter I — The Dawn</a> · Next: <span class="muted">Chapter III (to be added)</span></p>
       <p class="muted">Chronicle of Samogitia — Living Edition.</p>
     </footer>
   </div>


### PR DESCRIPTION
## Summary
- Update chapter2.html to use chapter1.html/chapter2.html links instead of hyphenated filenames

## Testing
- `python -m http.server 8000`
- `curl -I http://localhost:8000/chapter2.html`
- `curl -I http://localhost:8000/chapter1.html`


------
https://chatgpt.com/codex/tasks/task_e_68aa42daf8a4832e87fd70a7f4c79fa6