### PR TITLE
Add placeholder pages for missing sections

### DIFF
--- a/armies.html
+++ b/armies.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Armies of Samogitia</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
+    .container{max-width:900px;margin:3em auto;padding:0 2em}
+    h1{font-family:Georgia,serif;color:#8b0000}
+  </style>
+</head>
+<body>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(r => r.text())
+      .then(html => document.getElementById("nav-placeholder").innerHTML = html);
+  </script>
+  <main class="container">
+    <h1>Armies of Samogitia</h1>
+    <p>This page is under construction.</p>
+  </main>
+</body>
+</html>

--- a/economy.html
+++ b/economy.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Treasury & Economy</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
+    .container{max-width:900px;margin:3em auto;padding:0 2em}
+    h1{font-family:Georgia,serif;color:#8b0000}
+  </style>
+</head>
+<body>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(r => r.text())
+      .then(html => document.getElementById("nav-placeholder").innerHTML = html);
+  </script>
+  <main class="container">
+    <h1>Treasury & Economy</h1>
+    <p>This page is under construction.</p>
+  </main>
+</body>
+</html>

--- a/maps.html
+++ b/maps.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Atlas of Eastern Europe</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
+    .container{max-width:900px;margin:3em auto;padding:0 2em}
+    h1{font-family:Georgia,serif;color:#8b0000}
+  </style>
+</head>
+<body>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(r => r.text())
+      .then(html => document.getElementById("nav-placeholder").innerHTML = html);
+  </script>
+  <main class="container">
+    <h1>Atlas of Eastern Europe</h1>
+    <p>This page is under construction.</p>
+  </main>
+</body>
+</html>

--- a/navies.html
+++ b/navies.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Royal Navy</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
+    .container{max-width:900px;margin:3em auto;padding:0 2em}
+    h1{font-family:Georgia,serif;color:#8b0000}
+  </style>
+</head>
+<body>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(r => r.text())
+      .then(html => document.getElementById("nav-placeholder").innerHTML = html);
+  </script>
+  <main class="container">
+    <h1>Royal Navy</h1>
+    <p>This page is under construction.</p>
+  </main>
+</body>
+</html>

--- a/rulers.html
+++ b/rulers.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rulers & Advisors</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
+    .container{max-width:900px;margin:3em auto;padding:0 2em}
+    h1{font-family:Georgia,serif;color:#8b0000}
+  </style>
+</head>
+<body>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(r => r.text())
+      .then(html => document.getElementById("nav-placeholder").innerHTML = html);
+  </script>
+  <main class="container">
+    <h1>Rulers & Advisors</h1>
+    <p>This page is under construction.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add placeholder pages for armies, navies, rulers, economy, and maps so index links have destinations.
- Each placeholder pulls in the shared navigation and marks content as under construction.

## Testing
- `python - <<'PY'
import re
from pathlib import Path
text = Path('index.html').read_text()
links = re.findall(r'href="([^\"]+)"', text)
missing = [link for link in links if not Path(link).exists()]
print('Links found:', links)
print('Missing:', missing)
print('nav.html exists:', Path('nav.html').exists())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa42d8a9ec832e8351f3433110da05