### PR TITLE
Add meta descriptions and Open Graph tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title }}</title>
+  {% if page.description or site.description %}
+  <meta name="description" content="{{ page.description | default: site.description }}">
+  <meta property="og:description" content="{{ page.description | default: site.description }}">
+  {% endif %}
+  <meta property="og:title" content="{{ page.title }}">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
+  {% if page.image or site.image %}
+  <meta property="og:image" content="{{ page.image | default: site.image | absolute_url }}">
+  {% endif %}
+  <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
+</head>
+<body>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("{{ '/nav.html' | relative_url }}")
+      .then(r => r.text())
+      .then(html => document.getElementById("nav-placeholder").innerHTML = html);
+  </script>
+  {{ content }}
+</body>
+</html>

--- a/armies.html
+++ b/armies.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <title>Armies of Samogitia</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Overview of the armies fielded by Samogitia.">
+  <meta property="og:title" content="Armies of Samogitia">
+  <meta property="og:description" content="Overview of the armies fielded by Samogitia.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/armies.html">
   <style>
     body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
     .container{max-width:900px;margin:3em auto;padding:0 2em}

--- a/chapter1.html
+++ b/chapter1.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <title>Chapter I – The Dawn of Samogitia (1444)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Chronicles Samogitia's dawn in 1444 with key events and early facts.">
+  <meta property="og:title" content="Chapter I – The Dawn of Samogitia (1444)">
+  <meta property="og:description" content="Chronicles Samogitia's dawn in 1444 with key events and early facts.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/chapter1.html">
   <link rel="stylesheet" href="assets/css/styles.css">
   <style>
     /* Page-specific styles for Chapter I */

--- a/chapter2.html
+++ b/chapter2.html
@@ -5,6 +5,9 @@
   <title>Chapter II — Expansion & The First War (1445–1446) | Chronicle of Samogitia</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Chapter II details Samogitia’s early expansion and pre-war build-up, including the Iron Wolf and Black Death armies, and succession events in 1446." />
+  <meta property="og:title" content="Chapter II — Expansion & The First War (1445–1446) | Chronicle of Samogitia">
+  <meta property="og:description" content="Chapter II details Samogitia’s early expansion and pre-war build-up, including the Iron Wolf and Black Death armies, and succession events in 1446.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/chapter2.html">
   <link rel="stylesheet" href="assets/css/styles.css">
   <style>
     /* Page-specific styles for Chapter II */

--- a/economy.html
+++ b/economy.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <title>Treasury & Economy</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Track the treasury and economic status of Samogitia.">
+  <meta property="og:title" content="Treasury & Economy">
+  <meta property="og:description" content="Track the treasury and economic status of Samogitia.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/economy.html">
   <style>
     body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
     .container{max-width:900px;margin:3em auto;padding:0 2em}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>The Chronicle of Samogitia</title>
+  <meta name="description" content="Forged in wars and shadows, a kingdom awakens in Samogitia.">
+  <meta property="og:title" content="The Chronicle of Samogitia">
+  <meta property="og:description" content="Forged in wars and shadows, a kingdom awakens in Samogitia.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/">
   <link rel="stylesheet" href="assets/css/styles.css">
   <style>
     /* Page-specific styles for the index */

--- a/maps.html
+++ b/maps.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <title>Atlas of Eastern Europe</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Atlas of Eastern Europe in the Samogitian Chronicle.">
+  <meta property="og:title" content="Atlas of Eastern Europe">
+  <meta property="og:description" content="Atlas of Eastern Europe in the Samogitian Chronicle.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/maps.html">
   <style>
     body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
     .container{max-width:900px;margin:3em auto;padding:0 2em}

--- a/navies.html
+++ b/navies.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <title>Royal Navy</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Information on the Royal Navy of Samogitia.">
+  <meta property="og:title" content="Royal Navy">
+  <meta property="og:description" content="Information on the Royal Navy of Samogitia.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/navies.html">
   <style>
     body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
     .container{max-width:900px;margin:3em auto;padding:0 2em}

--- a/powers.html
+++ b/powers.html
@@ -5,6 +5,10 @@
   <title>Powers of 1444</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <link rel="stylesheet" href="assets/css/styles.css">
+  <meta name="description" content="Army and navy compositions of major powers in 1444.">
+  <meta property="og:title" content="Powers of 1444">
+  <meta property="og:description" content="Army and navy compositions of major powers in 1444.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/powers.html">
   <style>
     /* Page-specific styles for Powers */
     .container{max-width:1200px;}

--- a/rulers.html
+++ b/rulers.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <title>Rulers & Advisors</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Records of Samogitia's rulers and advisors.">
+  <meta property="og:title" content="Rulers & Advisors">
+  <meta property="og:description" content="Records of Samogitia's rulers and advisors.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/rulers.html">
   <style>
     body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
     .container{max-width:900px;margin:3em auto;padding:0 2em}

--- a/samogitia.html
+++ b/samogitia.html
@@ -5,6 +5,10 @@
   <title>Samogitia — Military & Navy Evolution</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <link rel="stylesheet" href="assets/css/styles.css">
+  <meta name="description" content="Evolution of Samogitia's military and navy over time.">
+  <meta property="og:title" content="Samogitia — Military & Navy Evolution">
+  <meta property="og:description" content="Evolution of Samogitia's military and navy over time.">
+  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/samogitia.html">
   <style>
     /* Page-specific styles for Samogitia evolution */
     .container{max-width:1000px;}


### PR DESCRIPTION
## Summary
- add per-page meta descriptions and Open Graph tags for shareable previews
- introduce a default layout that renders description and image metadata from front matter

## Testing
- `npx --yes html-validate armies.html chapter1.html chapter2.html economy.html index.html maps.html navies.html powers.html rulers.html samogitia.html` *(fails: 403 Forbidden from npm registry)*
- `python - <<'PY'
import re, pathlib
files = ['armies.html', 'chapter1.html', 'chapter2.html', 'economy.html', 'index.html', 'maps.html', 'navies.html', 'powers.html', 'rulers.html', 'samogitia.html']
for f in files:
    text = pathlib.Path(f).read_text()
    has_desc = bool(re.search(r'<meta name="description"', text, re.I))
    has_og_title = bool(re.search(r'<meta property="og:title"', text, re.I))
    has_og_desc = bool(re.search(r'<meta property="og:description"', text, re.I))
    has_og_url = bool(re.search(r'<meta property="og:url"', text, re.I))
    print(f"{f}: description={has_desc}, og:title={has_og_title}, og:description={has_og_desc}, og:url={has_og_url}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa51432210832ebd9c46b1114cfb46