### PR TITLE
Add datasets and charts for armies, navies, and economy pages

### DIFF
--- a/armies.html
+++ b/armies.html
@@ -19,7 +19,21 @@
   </script>
   <main class="container">
     <h1>Armies of Samogitia</h1>
-    <p>This page is under construction.</p>
+    <section>
+      <h2>Armies of the World 1444</h2>
+      <table id="armies-table">
+        <thead>
+          <tr><th>Nation</th><th>Infantry</th><th>Cavalry</th><th>Artillery</th><th>Total</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Samogitian Army Over Time</h2>
+      <canvas id="armies-chart"></canvas>
+    </section>
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script type="module" src="assets/js/armiesPage.js"></script>
 </body>
 </html>

--- a/assets/js/armiesData.js
+++ b/assets/js/armiesData.js
@@ -1,0 +1,26 @@
+export const ARMIES_1444 = [
+  { name: "Mamluks", inf: 11000, cav: 4000, art: 0, total: 15000 },
+  { name: "Muscovy", inf: 11000, cav: 4000, art: 0, total: 15000 },
+  { name: "Lithuania", inf: 11000, cav: 4000, art: 0, total: 15000 },
+  { name: "Aragon", inf: 7000, cav: 2000, art: 3000, total: 12000 },
+  { name: "Ottomans", inf: 9000, cav: 3000, art: 0, total: 12000 },
+  { name: "France", inf: 8000, cav: 3000, art: 0, total: 11000 },
+  { name: "Poland", inf: 8000, cav: 3000, art: 0, total: 11000 },
+  { name: "Uzbek", inf: 8000, cav: 2000, art: 0, total: 10000 },
+  { name: "Morocco", inf: 7000, cav: 3000, art: 0, total: 10000 },
+  { name: "Castille", inf: 8000, cav: 2000, art: 0, total: 10000 },
+  { name: "Bohemia", inf: 8000, cav: 2000, art: 0, total: 10000 },
+  { name: "England", inf: 8000, cav: 2000, art: 0, total: 10000 },
+  { name: "Kazan", inf: 7000, cav: 2000, art: 0, total: 9000 },
+  { name: "Venice", inf: 7000, cav: 2000, art: 0, total: 9000 },
+  { name: "Burgundy", inf: 7000, cav: 2000, art: 0, total: 9000 },
+  { name: "Hungary", inf: 7000, cav: 2000, art: 0, total: 9000 },
+  { name: "Austria", inf: 6000, cav: 2000, art: 0, total: 8000 },
+  { name: "Samogitia", inf: 5000, cav: 1000, art: 0, total: 6000 }
+];
+
+export const SAMOGITIA_ARMY_BY_YEAR = {
+  "1444": { inf: 5000, cav: 1000, art: 0 },
+  "1445": { inf: 5000, cav: 3000, art: 2000 },
+  "1446": { inf: 10000, cav: 6000, art: 4000 }
+};

--- a/assets/js/armiesPage.js
+++ b/assets/js/armiesPage.js
@@ -1,0 +1,39 @@
+import { ARMIES_1444, SAMOGITIA_ARMY_BY_YEAR } from './armiesData.js';
+
+function renderTable() {
+  const tbody = document.querySelector('#armies-table tbody');
+  ARMIES_1444.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${row.name}</td><td>${row.inf}</td><td>${row.cav}</td><td>${row.art}</td><td>${row.total}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderChart() {
+  const ctx = document.getElementById('armies-chart').getContext('2d');
+  const years = Object.keys(SAMOGITIA_ARMY_BY_YEAR);
+  const inf = years.map(y => SAMOGITIA_ARMY_BY_YEAR[y].inf);
+  const cav = years.map(y => SAMOGITIA_ARMY_BY_YEAR[y].cav);
+  const art = years.map(y => SAMOGITIA_ARMY_BY_YEAR[y].art);
+
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: years,
+      datasets: [
+        { label: 'Infantry', data: inf, backgroundColor: 'rgba(54, 162, 235, 0.5)' },
+        { label: 'Cavalry', data: cav, backgroundColor: 'rgba(255, 99, 132, 0.5)' },
+        { label: 'Artillery', data: art, backgroundColor: 'rgba(255, 206, 86, 0.5)' }
+      ]
+    },
+    options: {
+      scales: {
+        x: { stacked: true },
+        y: { beginAtZero: true, stacked: true }
+      }
+    }
+  });
+}
+
+renderTable();
+renderChart();

--- a/assets/js/economyData.js
+++ b/assets/js/economyData.js
@@ -1,0 +1,5 @@
+export const ECONOMY_BY_YEAR = {
+  "1444": { income: 50, expenses: 45 },
+  "1445": { income: 60, expenses: 55 },
+  "1446": { income: 70, expenses: 65 }
+};

--- a/assets/js/economyPage.js
+++ b/assets/js/economyPage.js
@@ -1,0 +1,36 @@
+import { ECONOMY_BY_YEAR } from './economyData.js';
+
+function renderTable() {
+  const tbody = document.querySelector('#economy-table tbody');
+  Object.entries(ECONOMY_BY_YEAR).forEach(([year, data]) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${year}</td><td>${data.income}</td><td>${data.expenses}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderChart() {
+  const ctx = document.getElementById('economy-chart').getContext('2d');
+  const years = Object.keys(ECONOMY_BY_YEAR);
+  const income = years.map(y => ECONOMY_BY_YEAR[y].income);
+  const expenses = years.map(y => ECONOMY_BY_YEAR[y].expenses);
+
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: years,
+      datasets: [
+        { label: 'Income', data: income, borderColor: 'green', fill: false },
+        { label: 'Expenses', data: expenses, borderColor: 'red', fill: false }
+      ]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+}
+
+renderTable();
+renderChart();

--- a/assets/js/naviesData.js
+++ b/assets/js/naviesData.js
@@ -1,0 +1,25 @@
+export const NAVIES_1444 = [
+  { name: "England", heavy: 4, light: 6, galley: 0, trans: 7, total: 17 },
+  { name: "Ragusa", heavy: 0, light: 7, galley: 5, trans: 4, total: 16 },
+  { name: "Venice", heavy: 0, light: 5, galley: 3, trans: 7, total: 15 },
+  { name: "Gotland", heavy: 0, light: 7, galley: 5, trans: 3, total: 15 },
+  { name: "Lubeck", heavy: 0, light: 6, galley: 4, trans: 4, total: 14 },
+  { name: "Denmark", heavy: 0, light: 2, galley: 6, trans: 6, total: 14 },
+  { name: "Mamluks", heavy: 0, light: 2, galley: 4, trans: 7, total: 13 },
+  { name: "Novgorod", heavy: 3, light: 5, galley: 0, trans: 5, total: 13 },
+  { name: "Aragon", heavy: 0, light: 2, galley: 5, trans: 6, total: 13 },
+  { name: "Ottomans", heavy: 0, light: 2, galley: 4, trans: 7, total: 13 },
+  { name: "Tunis", heavy: 0, light: 2, galley: 4, trans: 6, total: 12 },
+  { name: "Genoa", heavy: 0, light: 5, galley: 3, trans: 4, total: 12 },
+  { name: "Portugal", heavy: 3, light: 4, galley: 0, trans: 5, total: 12 },
+  { name: "Castile", heavy: 2, light: 3, galley: 0, trans: 7, total: 12 },
+  { name: "Teutonic Order", heavy: 0, light: 2, galley: 5, trans: 5, total: 12 },
+  { name: "Livonian Order", heavy: 0, light: 2, galley: 6, trans: 4, total: 12 },
+  { name: "Samogitia", heavy: 0, light: 0, galley: 0, trans: 0, total: 0 }
+];
+
+export const SAMOGITIA_NAVY_BY_YEAR = {
+  "1444": { heavy: 0, light: 0, galley: 0, trans: 0 },
+  "1445": { heavy: 0, light: 0, galley: 0, trans: 0 },
+  "1446": { heavy: 0, light: 0, galley: 0, trans: 0 }
+};

--- a/assets/js/naviesPage.js
+++ b/assets/js/naviesPage.js
@@ -1,0 +1,47 @@
+import { NAVIES_1444, SAMOGITIA_NAVY_BY_YEAR } from './naviesData.js';
+
+function renderTable() {
+  const tbody = document.querySelector('#navies-table tbody');
+  NAVIES_1444.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML =
+      `<td>${row.name}</td>` +
+      `<td>${row.heavy}</td>` +
+      `<td>${row.light}</td>` +
+      `<td>${row.galley}</td>` +
+      `<td>${row.trans}</td>` +
+      `<td>${row.total}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderChart() {
+  const ctx = document.getElementById('navies-chart').getContext('2d');
+  const years = Object.keys(SAMOGITIA_NAVY_BY_YEAR);
+  const heavy = years.map(y => SAMOGITIA_NAVY_BY_YEAR[y].heavy);
+  const light = years.map(y => SAMOGITIA_NAVY_BY_YEAR[y].light);
+  const galley = years.map(y => SAMOGITIA_NAVY_BY_YEAR[y].galley);
+  const trans = years.map(y => SAMOGITIA_NAVY_BY_YEAR[y].trans);
+
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: years,
+      datasets: [
+        { label: 'Heavy', data: heavy, backgroundColor: 'rgba(54, 162, 235, 0.5)' },
+        { label: 'Light', data: light, backgroundColor: 'rgba(255, 99, 132, 0.5)' },
+        { label: 'Galley', data: galley, backgroundColor: 'rgba(75, 192, 192, 0.5)' },
+        { label: 'Transport', data: trans, backgroundColor: 'rgba(255, 206, 86, 0.5)' }
+      ]
+    },
+    options: {
+      scales: {
+        x: { stacked: true },
+        y: { beginAtZero: true, stacked: true }
+      }
+    }
+  });
+}
+
+renderTable();
+renderChart();

--- a/economy.html
+++ b/economy.html
@@ -19,7 +19,21 @@
   </script>
   <main class="container">
     <h1>Treasury & Economy</h1>
-    <p>This page is under construction.</p>
+    <section>
+      <h2>Yearly Finances</h2>
+      <table id="economy-table">
+        <thead>
+          <tr><th>Year</th><th>Income</th><th>Expenses</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Income vs Expenses</h2>
+      <canvas id="economy-chart"></canvas>
+    </section>
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script type="module" src="assets/js/economyPage.js"></script>
 </body>
 </html>

--- a/navies.html
+++ b/navies.html
@@ -19,7 +19,21 @@
   </script>
   <main class="container">
     <h1>Royal Navy</h1>
-    <p>This page is under construction.</p>
+    <section>
+      <h2>Navies of the World 1444</h2>
+      <table id="navies-table">
+        <thead>
+          <tr><th>Nation</th><th>Heavy</th><th>Light</th><th>Galley</th><th>Transport</th><th>Total</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Samogitian Navy Over Time</h2>
+      <canvas id="navies-chart"></canvas>
+    </section>
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script type="module" src="assets/js/naviesPage.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add data modules for armies, navies, and economy statistics
- Replace under-construction sections with tables and Chart.js visualizations
- Wire up page scripts to render data-driven tables and charts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa514529ac832eb9103988e5715394