### PR TITLE
Add regions GeoJSON and cache in service worker

### DIFF
--- a/maps/regions.geojson
+++ b/maps/regions.geojson
@@ -1,0 +1,37 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Samogitia"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [21.0, 56.0],
+            [23.0, 56.0],
+            [23.0, 55.0],
+            [21.0, 55.0],
+            [21.0, 56.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Vilnius Region"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [24.0, 55.5],
+            [25.5, 55.5],
+            [25.5, 54.5],
+            [24.0, 54.5],
+            [24.0, 55.5]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'samogitian-cache-v1';
+const CACHE_NAME = 'samogitian-cache-v2';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
@@ -16,7 +16,8 @@ const ASSETS_TO_CACHE = [
   '/assets/js/militaryData.js',
   '/maps/heartland.png',
   '/maps/world.png',
-  '/maps/region.png'
+  '/maps/region.png',
+  '/maps/regions.geojson'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- add `maps/regions.geojson` with sample region polygons for Leaflet
- update service worker to cache new GeoJSON and bump cache version

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa55860698832e940b449a9789fd27