### PR TITLE
Add Historical Timeline to search index

### DIFF
--- a/assets/js/searchIndex.json
+++ b/assets/js/searchIndex.json
@@ -38,5 +38,9 @@
   {
     "title": "Samogitia — Military & Navy Evolution",
     "url": "samogitia.html"
+  },
+  {
+    "title": "Historical Timeline",
+    "url": "timeline.html"
   }
 ]


### PR DESCRIPTION
## Summary
- regenerate search index to include historical timeline page

## Testing
- `ruby scripts/generate_search_index.rb`
- `ruby -r json -e 'data=JSON.parse(File.read("assets/js/searchIndex.json")); results=data.select{|d| d["title"].downcase.include?("historical timeline")}; puts results'`


------
https://chatgpt.com/codex/tasks/task_e_68aa5587dbbc832e9c4af30f6b7fce7b