### PR TITLE
Link shared stylesheet across record pages

### DIFF
--- a/armies.html
+++ b/armies.html
@@ -7,14 +7,10 @@
   <meta name="description" content="Overview of the armies fielded by Samogitia.">
   <meta property="og:title" content="Armies of Samogitia">
   <meta property="og:description" content="Overview of the armies fielded by Samogitia.">
-  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/armies.html">
-  <style>
-    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
-    .container{max-width:900px;margin:3em auto;padding:0 2em}
-    h1{font-family:Georgia,serif;color:#8b0000}
-  </style>
-</head>
-<body>
+    <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/armies.html">
+    <link rel="stylesheet" href="assets/css/styles.css">
+  </head>
+  <body>
   <div id="nav-placeholder"></div>
   <script>
     fetch("nav.html")

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -98,4 +98,5 @@ canvas{
 .site-nav .links a.active{background:var(--accent);color:#fff;}
 @media (max-width:720px){.site-nav .links{gap:.4rem;}}
 
+h1{font-family:Georgia,serif;color:var(--accent);}
 h2{font-family:Georgia,serif;color:var(--accent);}

--- a/economy.html
+++ b/economy.html
@@ -7,14 +7,10 @@
   <meta name="description" content="Track the treasury and economic status of Samogitia.">
   <meta property="og:title" content="Treasury & Economy">
   <meta property="og:description" content="Track the treasury and economic status of Samogitia.">
-  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/economy.html">
-  <style>
-    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
-    .container{max-width:900px;margin:3em auto;padding:0 2em}
-    h1{font-family:Georgia,serif;color:#8b0000}
-  </style>
-</head>
-<body>
+    <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/economy.html">
+    <link rel="stylesheet" href="assets/css/styles.css">
+  </head>
+  <body>
   <div id="nav-placeholder"></div>
   <script>
     fetch("nav.html")

--- a/maps.html
+++ b/maps.html
@@ -18,14 +18,10 @@
   <meta name="description" content="Atlas of Eastern Europe in the Samogitian Chronicle.">
   <meta property="og:title" content="Atlas of Eastern Europe">
   <meta property="og:description" content="Atlas of Eastern Europe in the Samogitian Chronicle.">
-  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/maps.html">
-  <style>
-    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
-    .container{max-width:900px;margin:3em auto;padding:0 2em}
-    h1{font-family:Georgia,serif;color:#8b0000}
-  </style>
-</head>
-<body>
+    <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/maps.html">
+    <link rel="stylesheet" href="assets/css/styles.css">
+  </head>
+  <body>
   <div id="nav-placeholder"></div>
   <script>
     fetch("nav.html")

--- a/navies.html
+++ b/navies.html
@@ -7,14 +7,10 @@
   <meta name="description" content="Information on the Royal Navy of Samogitia.">
   <meta property="og:title" content="Royal Navy">
   <meta property="og:description" content="Information on the Royal Navy of Samogitia.">
-  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/navies.html">
-  <style>
-    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
-    .container{max-width:900px;margin:3em auto;padding:0 2em}
-    h1{font-family:Georgia,serif;color:#8b0000}
-  </style>
-</head>
-<body>
+    <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/navies.html">
+    <link rel="stylesheet" href="assets/css/styles.css">
+  </head>
+  <body>
   <div id="nav-placeholder"></div>
   <script>
     fetch("nav.html")

--- a/rulers.html
+++ b/rulers.html
@@ -7,14 +7,10 @@
   <meta name="description" content="Records of Samogitia's rulers and advisors.">
   <meta property="og:title" content="Rulers & Advisors">
   <meta property="og:description" content="Records of Samogitia's rulers and advisors.">
-  <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/rulers.html">
-  <style>
-    body{margin:0;background:#f9f9f9;color:#222;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;line-height:1.7}
-    .container{max-width:900px;margin:3em auto;padding:0 2em}
-    h1{font-family:Georgia,serif;color:#8b0000}
-  </style>
-</head>
-<body>
+    <meta property="og:url" content="https://rolandasd.github.io/SamogitianChronicle/rulers.html">
+    <link rel="stylesheet" href="assets/css/styles.css">
+  </head>
+  <body>
   <div id="nav-placeholder"></div>
   <script>
     fetch("nav.html")


### PR DESCRIPTION
## Summary
- Link global `styles.css` in armies, navies, economy, maps and rulers pages
- Remove duplicate inline styling and centralize heading styles

## Testing
- `npx --yes htmlhint armies.html navies.html economy.html maps.html rulers.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68aa55854e2c832e94029fd75bba376e