### PR TITLE
Add theme toggle control to navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,6 +12,7 @@
       <li><a href="{{ '/maps.html'      | relative_url }}">Atlas</a></li>
       <li><a href="{{ '/timeline.html'  | relative_url }}">Timeline</a></li>
     </ul>
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">Toggle Theme</button>
   </div>
 </nav>
 
@@ -27,3 +28,4 @@
     });
   })();
 </script>
+<script src="{{ '/assets/js/theme.js' | relative_url }}" defer></script>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -96,6 +96,8 @@ canvas{
 .site-nav .links a{display:block;padding:.35rem .6rem;text-decoration:none;color:#333;border-radius:.45rem;}
 .site-nav .links a:hover{background:#f6f6f6;}
 .site-nav .links a.active{background:var(--accent);color:#fff;}
+.site-nav #themeToggle{margin-left:auto;background:var(--card);border:1px solid var(--line);border-radius:.45rem;padding:.35rem .6rem;cursor:pointer;color:var(--ink);}
+.site-nav #themeToggle:hover{background:var(--line);}
 @media (max-width:720px){.site-nav .links{gap:.4rem;}}
 
 h2{font-family:Georgia,serif;color:var(--accent);}


### PR DESCRIPTION
## Summary
- Add a theme toggle button to the site navigation and load theme.js
- Style toggle button for light and dark themes

## Testing
- `node - <<'NODE'
const root={attrs:{},setAttribute(k,v){this.attrs[k]=v;},getAttribute(k){return this.attrs[k];}};
const btn={addEventListener:(e,cb)=>{btn._cb=cb;},click:()=>{btn._cb&&btn._cb();}};
global.document={documentElement:root,getElementById:id=>id==='themeToggle'?btn:null};
const store={};
global.localStorage={getItem:k=>store[k],setItem:(k,v)=>{store[k]=v;}};
require('./assets/js/theme.js');
console.log('initial', root.getAttribute('data-theme'));
btn.click();
console.log('after1', root.getAttribute('data-theme'));
btn.click();
console.log('after2', root.getAttribute('data-theme'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68aa55867204832ea2aa3ce18861d5f4