### PR TITLE
Align standalone nav.html with include template

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -5,28 +5,25 @@
       <li><a href="index.html">Home</a></li>
       <li><a href="powers.html">Great Powers</a></li>
       <li><a href="samogitia.html">Samogitia Evolution</a></li>
+      <li><a href="armies.html">Armies</a></li>
+      <li><a href="navies.html">Royal Navy</a></li>
+      <li><a href="rulers.html">Rulers &amp; Advisors</a></li>
+      <li><a href="economy.html">Economy</a></li>
+      <li><a href="maps.html">Atlas</a></li>
+      <li><a href="timeline.html">Timeline</a></li>
     </ul>
-    <input id="searchBox" type="text" placeholder="Search...">
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">Toggle Theme</button>
   </div>
-      <ul class="links">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="powers.html">Great Powers</a></li>
-        <li><a href="samogitia.html">Samogitia Evolution</a></li>
-      </ul>
-      <button id="themeToggle" aria-label="Toggle theme">Toggle Theme</button>
-    </div>
+</nav>
 
-  </nav>
-
-<script src="https://cdn.jsdelivr.net/npm/lunr/lunr.min.js"></script>
-<script src="assets/js/search.js"></script>
 <script>
-  // highlight active link
+  // Highlight the active link
   (function(){
-    const here = location.pathname.split("/").pop() || "index.html";
+    const here = location.pathname.replace(/\/+$/,'');
     document.querySelectorAll('.site-nav .links a').forEach(a=>{
-      if(a.getAttribute("href") === here){
-        a.classList.add("active");
+      const link = a.getAttribute('href').replace(/\/+$/,'');
+      if (link && (here.endsWith(link) || (here.endsWith('/SamogitianChronicle') && link.endsWith('/index.html')))) {
+        a.classList.add('active');
       }
     });
   })();
@@ -36,6 +33,5 @@
     navigator.serviceWorker.register('/service-worker.js');
   }
 </script>
-    })();
-  </script>
-  <script src="assets/js/theme.js" defer></script>
+<script src="assets/js/theme.js" defer></script>
+


### PR DESCRIPTION
## Summary
- Simplify `nav.html` to a single `.nav-wrap` and navigation list matching `_includes/nav.html`
- Remove duplicate markup and superfluous scripts, keeping only highlight logic, theme toggle, and service worker registration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa570bd054832eb8463e1b734e17da