### PR TITLE
Align navigation features and conditional scripts

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,20 +12,41 @@
       <li><a href="{{ '/maps.html'      | relative_url }}">Atlas</a></li>
       <li><a href="{{ '/timeline.html'  | relative_url }}">Timeline</a></li>
     </ul>
+    <input id="searchBox" type="text" placeholder="Search...">
     <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">Toggle Theme</button>
   </div>
 </nav>
 
 <script>
-  // Highlight the active link
   (function(){
-    const here = location.pathname.replace(/\/+$/,'');
-    document.querySelectorAll('.site-nav .links a').forEach(a=>{
-      const link = a.getAttribute('href').replace(/\/+$/,'');
-      if (link && (here.endsWith(link) || (here.endsWith('/SamogitianChronicle') && link.endsWith('/index.html')))) {
+    const here = location.pathname.replace(/\/+(?:index\.html)?$/, '').split('/').pop() || 'index.html';
+    document.querySelectorAll('.site-nav .links a').forEach(a => {
+      const link = a.getAttribute('href').replace(/\/+(?:index\.html)?$/, '').split('/').pop();
+      if(link === here){
         a.classList.add('active');
       }
     });
+
+    if(document.getElementById('themeToggle')){
+      const themeScript = document.createElement('script');
+      themeScript.src = "{{ '/assets/js/theme.js' | relative_url }}";
+      themeScript.defer = true;
+      document.head.appendChild(themeScript);
+    }
+
+    if(document.getElementById('searchBox')){
+      const lunrScript = document.createElement('script');
+      lunrScript.src = 'https://cdn.jsdelivr.net/npm/lunr/lunr.min.js';
+      lunrScript.onload = () => {
+        const searchScript = document.createElement('script');
+        searchScript.src = "{{ '/assets/js/search.js' | relative_url }}";
+        document.head.appendChild(searchScript);
+      };
+      document.head.appendChild(lunrScript);
+    }
+
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register('{{ '/service-worker.js' | relative_url }}');
+    }
   })();
 </script>
-<script src="{{ '/assets/js/theme.js' | relative_url }}" defer></script>

--- a/nav.html
+++ b/nav.html
@@ -5,37 +5,48 @@
       <li><a href="index.html">Home</a></li>
       <li><a href="powers.html">Great Powers</a></li>
       <li><a href="samogitia.html">Samogitia Evolution</a></li>
+      <li><a href="armies.html">Armies</a></li>
+      <li><a href="navies.html">Royal Navy</a></li>
+      <li><a href="rulers.html">Rulers &amp; Advisors</a></li>
+      <li><a href="economy.html">Economy</a></li>
+      <li><a href="maps.html">Atlas</a></li>
+      <li><a href="timeline.html">Timeline</a></li>
     </ul>
     <input id="searchBox" type="text" placeholder="Search...">
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">Toggle Theme</button>
   </div>
-      <ul class="links">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="powers.html">Great Powers</a></li>
-        <li><a href="samogitia.html">Samogitia Evolution</a></li>
-      </ul>
-      <button id="themeToggle" aria-label="Toggle theme">Toggle Theme</button>
-    </div>
+</nav>
 
-  </nav>
-
-<script src="https://cdn.jsdelivr.net/npm/lunr/lunr.min.js"></script>
-<script src="assets/js/search.js"></script>
 <script>
-  // highlight active link
   (function(){
-    const here = location.pathname.split("/").pop() || "index.html";
-    document.querySelectorAll('.site-nav .links a').forEach(a=>{
-      if(a.getAttribute("href") === here){
-        a.classList.add("active");
+    const here = location.pathname.replace(/\/+(?:index\.html)?$/, '').split('/').pop() || 'index.html';
+    document.querySelectorAll('.site-nav .links a').forEach(a => {
+      const link = a.getAttribute('href').replace(/\/+(?:index\.html)?$/, '').split('/').pop();
+      if(link === here){
+        a.classList.add('active');
       }
     });
+
+    if(document.getElementById('themeToggle')){
+      const themeScript = document.createElement('script');
+      themeScript.src = 'assets/js/theme.js';
+      themeScript.defer = true;
+      document.head.appendChild(themeScript);
+    }
+
+    if(document.getElementById('searchBox')){
+      const lunrScript = document.createElement('script');
+      lunrScript.src = 'https://cdn.jsdelivr.net/npm/lunr/lunr.min.js';
+      lunrScript.onload = () => {
+        const searchScript = document.createElement('script');
+        searchScript.src = 'assets/js/search.js';
+        document.head.appendChild(searchScript);
+      };
+      document.head.appendChild(lunrScript);
+    }
+
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register('/service-worker.js');
+    }
   })();
 </script>
-<script>
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/service-worker.js');
-  }
-</script>
-    })();
-  </script>
-  <script src="assets/js/theme.js" defer></script>


### PR DESCRIPTION
## Summary
- standardize navigation to include both search box and theme toggle
- load theme and search scripts only when corresponding elements are present
- register service worker from navigation template

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa570e96c8832eaec158508fb4b65b