### PR TITLE
Remove conflict markers and consolidate nav scripts

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -19,12 +19,6 @@
 
 <script>
   (function(){
-    const here = location.pathname.replace(/\/+(?:index\.html)?$/, '').split('/').pop() || 'index.html';
-    document.querySelectorAll('.site-nav .links a').forEach(a => {
-      const link = a.getAttribute('href').replace(/\/+(?:index\.html)?$/, '').split('/').pop();
-      if(link === here){
-  // Highlight the active link
-  (function(){
     const here = location.pathname.replace(/\/+$/,'');
     document.querySelectorAll('.site-nav .links a').forEach(a=>{
       const link = a.getAttribute('href').replace(/\/+$/,'');
@@ -56,11 +50,4 @@
     }
   })();
 </script>
-=======
-<script>
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/service-worker.js');
-  }
-</script>
-<script src="assets/js/theme.js" defer></script>
 


### PR DESCRIPTION
## Summary
- Clean up `nav.html` by removing leftover conflict markers and duplicate scripts
- Centralize theme toggle, search, and service worker initialization into a single script block

## Testing
- `tidy -qe nav.html` *(fails: tidy not installed)*
- `apt-get update` *(fails: repositories not signed)*
- `pip install --user html5lib` *(fails: cannot connect to proxy)*
- `python - <<'PY' from html.parser import HTMLParser; HTMLParser().feed(open('nav.html').read()); print('Parsed successfully') PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a031a74832e90ed300c3e77a7c9