### PR TITLE
Enable horizontal scrolling for data tables

### DIFF
--- a/armies.html
+++ b/armies.html
@@ -8,12 +8,14 @@ description: Overview of the armies fielded by Samogitia.
   <h1>Armies of Samogitia</h1>
   <section>
     <h2>Armies of the World 1444</h2>
-    <table id="armies-table">
-      <thead>
-        <tr><th>Nation</th><th>Infantry</th><th>Cavalry</th><th>Artillery</th><th>Total</th></tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <div class="table-container">
+      <table id="armies-table">
+        <thead>
+          <tr><th>Nation</th><th>Infantry</th><th>Cavalry</th><th>Artillery</th><th>Total</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </section>
   <section>
     <h2>Samogitian Army Over Time</h2>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -52,13 +52,15 @@ html,body{
   font-size:1.2rem;
   margin:.2rem 0 1rem;
 }
+.table-container{
+  overflow-x:auto;
+}
 table{
   width:100%;
   border-collapse:collapse;
   background:#fcfcfc;
   border:1px solid var(--line);
   border-radius:.4rem;
-  overflow:hidden;
   font-size:.95rem;
 }
 th,td{
@@ -72,6 +74,13 @@ th{
 }
 tr:last-child td{
   border-bottom:0;
+}
+
+@media (max-width:600px){
+  th,td{
+    padding:.3rem .4rem;
+    font-size:.8rem;
+  }
 }
 .muted{color:var(--muted);font-size:.9rem;}
 .back{

--- a/economy.html
+++ b/economy.html
@@ -8,12 +8,14 @@ description: Track the treasury and economic status of Samogitia.
   <h1>Treasury & Economy</h1>
   <section>
     <h2>Yearly Finances</h2>
-    <table id="economy-table">
-      <thead>
-        <tr><th>Year</th><th>Income</th><th>Expenses</th></tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <div class="table-container">
+      <table id="economy-table">
+        <thead>
+          <tr><th>Year</th><th>Income</th><th>Expenses</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </section>
   <section>
     <h2>Income vs Expenses</h2>

--- a/navies.html
+++ b/navies.html
@@ -8,12 +8,14 @@ description: Information on the Royal Navy of Samogitia.
   <h1>Royal Navy</h1>
   <section>
     <h2>Navies of the World 1444</h2>
-    <table id="navies-table">
-      <thead>
-        <tr><th>Nation</th><th>Heavy</th><th>Light</th><th>Galley</th><th>Transport</th><th>Total</th></tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <div class="table-container">
+      <table id="navies-table">
+        <thead>
+          <tr><th>Nation</th><th>Heavy</th><th>Light</th><th>Galley</th><th>Transport</th><th>Total</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </section>
   <section>
     <h2>Samogitian Navy Over Time</h2>

--- a/powers.html
+++ b/powers.html
@@ -30,18 +30,20 @@ description: Army and navy compositions of major powers in 1444.
       <div class="toolbar">
         <button id="highlightArmy" type="button">Top Army</button>
       </div>
-      <table id="army-table">
-        <thead>
-          <tr>
-            <th>Country</th>
-            <th>Total</th>
-            <th>Inf</th>
-            <th>Cav</th>
-            <th>Art</th>
-          </tr>
-        </thead>
-        <tbody id="army-rows"></tbody>
-      </table>
+      <div class="table-container">
+        <table id="army-table">
+          <thead>
+            <tr>
+              <th>Country</th>
+              <th>Total</th>
+              <th>Inf</th>
+              <th>Cav</th>
+              <th>Art</th>
+            </tr>
+          </thead>
+          <tbody id="army-rows"></tbody>
+        </table>
+      </div>
       <p class="muted">Totals = Infantry + Cavalry + Artillery</p>
     </article>
 
@@ -51,19 +53,21 @@ description: Army and navy compositions of major powers in 1444.
       <div class="toolbar">
         <button id="highlightNavy" type="button">Top Navy</button>
       </div>
-      <table id="navy-table">
-        <thead>
-          <tr>
-            <th>Country</th>
-            <th>Total</th>
-            <th>Heavy</th>
-            <th>Light</th>
-            <th>Galley</th>
-            <th>Transport</th>
-          </tr>
-        </thead>
-        <tbody id="navy-rows"></tbody>
-      </table>
+      <div class="table-container">
+        <table id="navy-table">
+          <thead>
+            <tr>
+              <th>Country</th>
+              <th>Total</th>
+              <th>Heavy</th>
+              <th>Light</th>
+              <th>Galley</th>
+              <th>Transport</th>
+            </tr>
+          </thead>
+          <tbody id="navy-rows"></tbody>
+        </table>
+      </div>
       <p class="muted">Totals = Heavy + Light + Galleys + Transports</p>
     </article>
   </section>
@@ -71,32 +75,34 @@ description: Army and navy compositions of major powers in 1444.
   <!-- Samogitia named armies (optional helper table) -->
   <section class="card" style="margin-top:1rem;">
     <h2>Samogitia Armies (1444–1446)</h2>
-    <table>
-      <thead>
-        <tr><th>Year</th><th>Name</th><th>Commander</th><th>Inf</th><th>Cav</th><th>Art</th><th>Total</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>1444</td><td><em>—</em></td><td><em>—</em></td>
-          <td>5,000</td><td>1,000</td><td>0</td><td>6,000</td>
-        </tr>
-        <tr>
-          <td>1445</td><td>Iron Wolf</td><td>Daugvilas Tyzenhaus</td>
-          <td>5,000</td><td>3,000</td><td>2,000</td><td>10,000</td>
-        </tr>
-        <tr>
-          <td>1446</td><td>Black Death</td><td>Kantibutas Giedraiciai</td>
-          <td>5,000</td><td>3,000</td><td>2,000</td><td>10,000</td>
-        </tr>
-        <tr>
-          <td colspan="3"><strong>1446 Combined</strong></td>
-          <td><strong>10,000</strong></td>
-          <td><strong>6,000</strong></td>
-          <td><strong>4,000</strong></td>
-          <td><strong>20,000</strong></td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr><th>Year</th><th>Name</th><th>Commander</th><th>Inf</th><th>Cav</th><th>Art</th><th>Total</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1444</td><td><em>—</em></td><td><em>—</em></td>
+            <td>5,000</td><td>1,000</td><td>0</td><td>6,000</td>
+          </tr>
+          <tr>
+            <td>1445</td><td>Iron Wolf</td><td>Daugvilas Tyzenhaus</td>
+            <td>5,000</td><td>3,000</td><td>2,000</td><td>10,000</td>
+          </tr>
+          <tr>
+            <td>1446</td><td>Black Death</td><td>Kantibutas Giedraiciai</td>
+            <td>5,000</td><td>3,000</td><td>2,000</td><td>10,000</td>
+          </tr>
+          <tr>
+            <td colspan="3"><strong>1446 Combined</strong></td>
+            <td><strong>10,000</strong></td>
+            <td><strong>6,000</strong></td>
+            <td><strong>4,000</strong></td>
+            <td><strong>20,000</strong></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <p class="muted">Combined totals assume both armies are active in 1446.</p>
   </section>
 

--- a/samogitia.html
+++ b/samogitia.html
@@ -21,74 +21,78 @@ description: Evolution of Samogitia's military and navy over time.
   <!-- 1444 baseline -->
   <section class="card">
     <h2>Armies of 1444</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Army</th>
-          <th>Commander</th>
-          <th>Total</th>
-          <th>Inf</th>
-          <th>Cav</th>
-          <th>Art</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Field Army (later “Iron Wolf”)</td>
-          <td>Daugvilas Tyzenhaus</td>
-          <td>6,000</td>
-          <td>5,000</td>
-          <td>1,000</td>
-          <td>0</td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>Army</th>
+            <th>Commander</th>
+            <th>Total</th>
+            <th>Inf</th>
+            <th>Cav</th>
+            <th>Art</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Field Army (later “Iron Wolf”)</td>
+            <td>Daugvilas Tyzenhaus</td>
+            <td>6,000</td>
+            <td>5,000</td>
+            <td>1,000</td>
+            <td>0</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <p class="muted">A structured field army existed in 1444; it was formally named <em>Iron Wolf</em> in June 1445.</p>
   </section>
 
   <!-- 1445–1446 named armies -->
   <section class="card">
     <h2>Armies of 1445–1446</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Year</th>
-          <th>Army</th>
-          <th>Commander</th>
-          <th>Total</th>
-          <th>Inf</th>
-          <th>Cav</th>
-          <th>Art</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>1445 (June)</td>
-          <td>Iron Wolf</td>
-          <td>Daugvilas Tyzenhaus</td>
-          <td>10,000</td>
-          <td>5,000</td>
-          <td>3,000</td>
-          <td>2,000</td>
-        </tr>
-        <tr>
-          <td>1446</td>
-          <td>Black Death</td>
-          <td>Kantibutas Giedraiciai</td>
-          <td>10,000</td>
-          <td>5,000</td>
-          <td>3,000</td>
-          <td>2,000</td>
-        </tr>
-        <tr>
-          <td colspan="3"><strong>1446 Combined</strong></td>
-          <td><strong>20,000</strong></td>
-          <td><strong>10,000</strong></td>
-          <td><strong>6,000</strong></td>
-          <td><strong>4,000</strong></td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>Year</th>
+            <th>Army</th>
+            <th>Commander</th>
+            <th>Total</th>
+            <th>Inf</th>
+            <th>Cav</th>
+            <th>Art</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1445 (June)</td>
+            <td>Iron Wolf</td>
+            <td>Daugvilas Tyzenhaus</td>
+            <td>10,000</td>
+            <td>5,000</td>
+            <td>3,000</td>
+            <td>2,000</td>
+          </tr>
+          <tr>
+            <td>1446</td>
+            <td>Black Death</td>
+            <td>Kantibutas Giedraiciai</td>
+            <td>10,000</td>
+            <td>5,000</td>
+            <td>3,000</td>
+            <td>2,000</td>
+          </tr>
+          <tr>
+            <td colspan="3"><strong>1446 Combined</strong></td>
+            <td><strong>20,000</strong></td>
+            <td><strong>10,000</strong></td>
+            <td><strong>6,000</strong></td>
+            <td><strong>4,000</strong></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <p class="muted">Combined totals assume both armies are active in 1446.</p>
   </section>
 


### PR DESCRIPTION
## Summary
- Wrap data tables in a `.table-container` wrapper for all pages
- Add mobile-friendly table styling and responsive font/padding adjustments

## Testing
- `python - <<'PY' ...` (verified each table is wrapped)
- `npx -p puppeteer@21 node - <<'NODE'` *(fails: 403 Forbidden to download package)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5a03ffb0832e9a254ca6c2affbbe