### PR TITLE
Load navToggle script for mobile nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -50,3 +50,4 @@
     }
   })();
 </script>
+<script src="{{ '/assets/js/navToggle.js' | relative_url }}" defer></script>


### PR DESCRIPTION
## Summary
- load navToggle.js in navigation include so the hamburger button can toggle the menu

## Testing
- `gem install jekyll` (fails: 403 Forbidden)
- `jekyll build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa5da81274832ebe349122c66ae79c