### PR TITLE
Add canonical and Open Graph meta tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,9 @@
   {% if page.image or site.image %}
   <meta property="og:image" content="{{ page.image | default: site.image | absolute_url }}">
   {% endif %}
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
+  <meta property="og:site_name" content="{{ site.title }}">
+  <meta property="og:type" content="website">
   <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add canonical link to default layout
- include Open Graph site_name and type meta tags

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5da9c87c832e809e429266e6d8c8