### PR TITLE
Add offline fallback page and update service worker

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Offline</title>
+<style>
+  body { font-family: sans-serif; text-align: center; padding-top: 20%; background: #f8f8f8; color: #333; }
+</style>
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>Please check your internet connection.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,6 +15,7 @@ const ASSETS_TO_CACHE = [
   '/timeline.html',
   '/assets/css/styles.css',
   '/assets/js/militaryData.js',
+  '/offline.html',
   '/maps/heartland.png',
   '/maps/world.png',
   '/maps/region.png',
@@ -39,7 +40,13 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches
+      .match(event.request)
+      .then(
+        response =>
+          response ||
+          fetch(event.request).catch(() => caches.match('offline.html'))
+      )
   );
 });
 


### PR DESCRIPTION
## Summary
- Add minimal `offline.html` page for offline visits
- Cache offline page in service worker assets list
- Provide offline fallback from service worker fetch handler

## Testing
- `node --check service-worker.js`
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/offline.html`


------
https://chatgpt.com/codex/tasks/task_e_68aa5dab8fe4832ea6af8f854d3498a0