### PR TITLE
feat: add timeline range filter

### DIFF
--- a/assets/js/timelineData.js
+++ b/assets/js/timelineData.js
@@ -3,5 +3,12 @@ export const TIMELINE_EVENTS = [
   { year: 1445, event: "Alliance forged with neighboring tribes" },
   { year: 1446, event: "First territorial expansion" },
   { year: 1447, event: "Royal navy launched" },
-  { year: 1448, event: "Capital fortified and court established" }
+  { year: 1448, event: "Capital fortified and court established" },
+  { year: 1450, event: "Diplomatic mission opens trade routes" },
+  { year: 1453, event: "Cultural renaissance begins in the capital" },
+  { year: 1458, event: "Samogitian scholars complete grand chronicle" },
+  { year: 1467, event: "Great plague challenges the kingdom" },
+  { year: 1475, event: "Samogitia repels northern invasion" },
+  { year: 1484, event: "Construction of the royal library" },
+  { year: 1492, event: "Voyagers chart distant seas" }
 ];

--- a/timeline.html
+++ b/timeline.html
@@ -6,6 +6,7 @@ description: Key events shaping Samogitia.
 
 <style>
   .timeline-container{max-width:800px;margin:2rem auto;padding:0 1rem;}
+  .controls{display:flex;gap:.5rem;align-items:center;margin-bottom:1rem;flex-wrap:wrap;}
   .timeline{position:relative;padding-left:2rem;border-left:2px solid var(--line);}
   .timeline-item{position:relative;margin:1rem 0;padding-left:1rem;}
   .timeline-year{font-weight:700;color:#4b0000;}
@@ -19,16 +20,69 @@ description: Key events shaping Samogitia.
 </header>
 
 <main class="timeline-container">
+  <div class="controls">
+    <label>Start <input type="range" id="startYear"></label>
+    <span id="startVal"></span>
+    <label>End <input type="range" id="endYear"></label>
+    <span id="endVal"></span>
+    <button id="resetRange" type="button">Reset</button>
+  </div>
   <div id="timeline" class="timeline"></div>
 </main>
 
 <script type="module">
   import { TIMELINE_EVENTS } from "./assets/js/timelineData.js";
   const container = document.getElementById('timeline');
-  [...TIMELINE_EVENTS].sort((a,b)=>a.year-b.year).forEach(ev=>{
-    const item=document.createElement('div');
-    item.className='timeline-item';
-    item.innerHTML=`<span class="timeline-year">${ev.year}</span><div class="timeline-content">${ev.event}</div>`;
-    container.appendChild(item);
+  const startInput = document.getElementById('startYear');
+  const endInput = document.getElementById('endYear');
+  const startVal = document.getElementById('startVal');
+  const endVal = document.getElementById('endVal');
+  const resetBtn = document.getElementById('resetRange');
+
+  const years = TIMELINE_EVENTS.map(e=>e.year);
+  const minYear = Math.min(...years);
+  const maxYear = Math.max(...years);
+
+  startInput.min = endInput.min = minYear;
+  startInput.max = endInput.max = maxYear;
+  startInput.value = minYear;
+  endInput.value = maxYear;
+
+  function render(){
+    const start = parseInt(startInput.value);
+    const end = parseInt(endInput.value);
+    startVal.textContent = start;
+    endVal.textContent = end;
+    container.innerHTML='';
+    TIMELINE_EVENTS.filter(ev=>ev.year>=start && ev.year<=end)
+      .sort((a,b)=>a.year-b.year)
+      .forEach(ev=>{
+        const item=document.createElement('div');
+        item.className='timeline-item';
+        item.innerHTML=`<span class="timeline-year">${ev.year}</span><div class="timeline-content">${ev.event}</div>`;
+        container.appendChild(item);
+      });
+  }
+
+  startInput.addEventListener('input',()=>{
+    if(parseInt(startInput.value)>parseInt(endInput.value)){
+      endInput.value=startInput.value;
+    }
+    render();
   });
+
+  endInput.addEventListener('input',()=>{
+    if(parseInt(endInput.value)<parseInt(startInput.value)){
+      startInput.value=endInput.value;
+    }
+    render();
+  });
+
+  resetBtn.addEventListener('click',()=>{
+    startInput.value=minYear;
+    endInput.value=maxYear;
+    render();
+  });
+
+  render();
 </script>


### PR DESCRIPTION
## Summary
- expand timeline data with events through the late 15th century
- add start/end year sliders and reset control for the timeline
- dynamically filter visible timeline events based on selected range

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f8d82b4832ea848182c37acb7e0