### PR TITLE
Add map layer toggles for regions, heartland, and world

### DIFF
--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -1,9 +1,20 @@
 document.addEventListener('DOMContentLoaded', () => {
   const map = L.map('map').setView([55.0, 23.0], 6);
 
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  const base = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-  }).addTo(map);
+  });
+  base.addTo(map);
+
+  const regionsLayer = L.layerGroup();
+  const heartlandLayer = L.layerGroup();
+  const worldLayer = L.layerGroup();
+
+  const heartlandOverlay = L.imageOverlay('maps/heartland.png', [[50, 15], [60, 30]]);
+  heartlandOverlay.addTo(heartlandLayer);
+
+  const worldOverlay = L.imageOverlay('maps/world.png', [[-90, -180], [90, 180]]);
+  worldOverlay.addTo(worldLayer);
 
   fetch('maps/regions.geojson')
     .then(response => response.json())
@@ -20,7 +31,45 @@ document.addEventListener('DOMContentLoaded', () => {
             layer.bindTooltip(feature.properties.name);
           }
         }
-      }).addTo(map);
+      }).addTo(regionsLayer);
     })
     .catch(err => console.error('Error loading regions:', err));
+
+  regionsLayer.addTo(map);
+
+  const overlays = {
+    Regions: regionsLayer,
+    Heartland: heartlandLayer,
+    World: worldLayer
+  };
+
+  L.control.layers(null, overlays).addTo(map);
+
+  const regionsCheckbox = document.getElementById('layer-regions');
+  const heartlandCheckbox = document.getElementById('layer-heartland');
+  const worldCheckbox = document.getElementById('layer-world');
+
+  regionsCheckbox.addEventListener('change', e => {
+    if (e.target.checked) {
+      map.addLayer(regionsLayer);
+    } else {
+      map.removeLayer(regionsLayer);
+    }
+  });
+
+  heartlandCheckbox.addEventListener('change', e => {
+    if (e.target.checked) {
+      map.addLayer(heartlandLayer);
+    } else {
+      map.removeLayer(heartlandLayer);
+    }
+  });
+
+  worldCheckbox.addEventListener('change', e => {
+    if (e.target.checked) {
+      map.addLayer(worldLayer);
+    } else {
+      map.removeLayer(worldLayer);
+    }
+  });
 });

--- a/maps.html
+++ b/maps.html
@@ -18,6 +18,11 @@ description: Atlas of Eastern Europe in the Samogitian Chronicle.
 
 <main class="container">
   <h1>Atlas of Eastern Europe</h1>
+  <div id="map-toolbar" style="margin-bottom: 10px;">
+    <label><input type="checkbox" id="layer-regions" checked /> Regions</label>
+    <label><input type="checkbox" id="layer-heartland" /> Heartland</label>
+    <label><input type="checkbox" id="layer-world" /> World</label>
+  </div>
   <div id="map" style="height: 500px;"></div>
 </main>
 <script src="assets/js/maps.js"></script>


### PR DESCRIPTION
## Summary
- Add toolbar with checkboxes to toggle Regions, Heartland, and World map layers.
- Load Heartland and World image overlays and organize layers with `L.layerGroup` and `L.control.layers`.
- Enable interactive layer toggling via custom checkboxes and Leaflet controls.

## Testing
- `node --check assets/js/maps.js`
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f8ed90c832e9288ee20de285f29