### PR TITLE
Improve search index and accessibility

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -6,6 +6,7 @@
     const idx = lunr(function(){
       this.ref('url');
       this.field('title');
+      this.field('description');
       data.forEach(doc => this.add(doc));
     });
 
@@ -16,18 +17,46 @@
     resultsBox.style.border = '1px solid #ccc';
     resultsBox.style.display = 'none';
     resultsBox.style.zIndex = '1000';
+    resultsBox.setAttribute('role', 'listbox');
     input.parentNode.appendChild(resultsBox);
+
+    let currentIndex = -1;
+
+    function hideResults(){
+      resultsBox.style.display = 'none';
+      resultsBox.innerHTML = '';
+      currentIndex = -1;
+    }
+
+    function updateSelection(newIndex){
+      const options = resultsBox.querySelectorAll('a[role="option"]');
+      if(options.length === 0) return;
+      if(newIndex < 0) newIndex = 0;
+      if(newIndex >= options.length) newIndex = options.length - 1;
+      currentIndex = newIndex;
+      options.forEach((opt,i) => {
+        if(i === currentIndex){
+          opt.classList.add('selected');
+          opt.style.background = '#eef';
+          opt.focus();
+        } else {
+          opt.classList.remove('selected');
+          opt.style.background = '';
+        }
+      });
+    }
 
     input.addEventListener('input', function(){
       const query = this.value.trim();
       resultsBox.innerHTML = '';
+      currentIndex = -1;
       if(!query){
-        resultsBox.style.display = 'none';
+        hideResults();
         return;
       }
       const results = idx.search(query);
       if(results.length === 0){
-        resultsBox.style.display = 'none';
+        hideResults();
         return;
       }
       resultsBox.style.display = 'block';
@@ -36,12 +65,61 @@
         if(match){
           const link = document.createElement('a');
           link.href = match.url;
-          link.textContent = match.title;
+          link.setAttribute('role','option');
+          link.tabIndex = -1;
           link.style.display = 'block';
           link.style.padding = '4px 8px';
+          const title = document.createElement('div');
+          title.textContent = match.title;
+          title.style.fontWeight = 'bold';
+          const desc = document.createElement('div');
+          desc.textContent = match.description;
+          desc.style.fontSize = 'smaller';
+          link.appendChild(title);
+          link.appendChild(desc);
           resultsBox.appendChild(link);
         }
       });
+    });
+
+    function handleKey(e){
+      if(resultsBox.style.display === 'none') return;
+      const options = resultsBox.querySelectorAll('a[role="option"]');
+      switch(e.key){
+        case 'ArrowDown':
+          e.preventDefault();
+          updateSelection(currentIndex + 1);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          if(currentIndex <= 0){
+            currentIndex = -1;
+            input.focus();
+          } else {
+            updateSelection(currentIndex - 1);
+          }
+          break;
+        case 'Enter':
+          if(currentIndex >= 0 && options[currentIndex]){
+            window.location = options[currentIndex].href;
+          }
+          break;
+        case 'Escape':
+          hideResults();
+          input.focus();
+          break;
+      }
+    }
+
+    input.addEventListener('keydown', handleKey);
+    resultsBox.addEventListener('keydown', handleKey);
+
+    input.addEventListener('blur', () => {
+      setTimeout(() => {
+        if(!resultsBox.contains(document.activeElement)){
+          hideResults();
+        }
+      }, 100);
     });
   } catch(err) {
     console.error('Search init failed', err);

--- a/assets/js/searchIndex.json
+++ b/assets/js/searchIndex.json
@@ -1,50 +1,67 @@
 [
   {
-    "title": "armies",
-    "url": "armies.html"
+    "title": "Armies of Samogitia",
+    "url": "armies.html",
+    "description": "Overview of the armies fielded by Samogitia."
   },
   {
-    "title": "chapter1",
-    "url": "chapter1.html"
+    "title": "Chapter I – The Dawn of Samogitia (1444)",
+    "url": "chapter1.html",
+    "description": "Chronicles Samogitia's dawn in 1444 with key events and early facts."
   },
   {
-    "title": "chapter2",
-    "url": "chapter2.html"
+    "title": "Chapter II — Expansion & The First War (1445–1446) | Chronicle of Samogitia",
+    "url": "chapter2.html",
+    "description": "Chapter II details Samogitia’s early expansion and pre-war build-up, including the Iron Wolf and Black Death armies, and succession events in 1446."
   },
   {
-    "title": "chronicle",
-    "url": "chronicle.html"
+    "title": "Full Chronicle",
+    "url": "chronicle.html",
+    "description": "All chapters combined in one continuous page."
   },
   {
-    "title": "economy",
-    "url": "economy.html"
+    "title": "Treasury & Economy",
+    "url": "economy.html",
+    "description": "Track the treasury and economic status of Samogitia."
   },
   {
-    "title": "index",
-    "url": "index.html"
+    "title": "The Chronicle of Samogitia",
+    "url": "index.html",
+    "description": "Forged in wars and shadows, a kingdom awakens in Samogitia."
   },
   {
-    "title": "maps",
-    "url": "maps.html"
+    "title": "Atlas of Eastern Europe",
+    "url": "maps.html",
+    "description": "Atlas of Eastern Europe in the Samogitian Chronicle."
   },
   {
-    "title": "navies",
-    "url": "navies.html"
+    "title": "Royal Navy",
+    "url": "navies.html",
+    "description": "Information on the Royal Navy of Samogitia."
   },
   {
-    "title": "powers",
-    "url": "powers.html"
+    "title": "Offline",
+    "url": "offline.html",
+    "description": "You are offline"
   },
   {
-    "title": "rulers",
-    "url": "rulers.html"
+    "title": "Powers of 1444",
+    "url": "powers.html",
+    "description": "Army and navy compositions of major powers in 1444."
   },
   {
-    "title": "samogitia",
-    "url": "samogitia.html"
+    "title": "Rulers & Advisors",
+    "url": "rulers.html",
+    "description": "Records of Samogitia's rulers and advisors."
   },
   {
-    "title": "timeline",
-    "url": "timeline.html"
+    "title": "Samogitia — Military & Navy Evolution",
+    "url": "samogitia.html",
+    "description": "Evolution of Samogitia's military and navy over time."
+  },
+  {
+    "title": "Historical Timeline",
+    "url": "timeline.html",
+    "description": "Key events shaping Samogitia."
   }
 ]

--- a/scripts/generate_search_index.rb
+++ b/scripts/generate_search_index.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
-# Generates a simple search index of page titles and URLs
 require 'json'
+require 'yaml'
+
 root = File.expand_path('..', __dir__)
 output = File.join(root, 'assets', 'js', 'searchIndex.json')
 
@@ -8,8 +9,20 @@ pages = Dir.glob(File.join(root, '*.html')).reject { |f| File.basename(f) == 'na
 
 index = pages.map do |file|
   html = File.read(file)
-  title = html[/<title>(.*?)<\/title>/m, 1] || File.basename(file, '.html')
-  { title: title.strip, url: File.basename(file) }
+
+  front = {}
+  body = html
+  if html =~ /\A---\s*\n(.*?)\n---\s*\n/m
+    front = YAML.safe_load($1) || {}
+    body = html.sub(/\A---\s*\n.*?\n---\s*\n/m, '')
+  end
+
+  title = front['title'] || body[/<title>(.*?)<\/title>/m, 1] || File.basename(file, '.html')
+  description = front['description'] ||
+                body[/<meta name=["']description["'] content=["'](.*?)["']/m, 1] ||
+                body[/<h1[^>]*>(.*?)<\/h1>/m, 1] || ''
+
+  { title: title.strip, url: File.basename(file), description: description.strip }
 end
 
 File.write(output, JSON.pretty_generate(index))


### PR DESCRIPTION
## Summary
- Include meta description or first heading in generated search index
- Display descriptions in search results with ARIA listbox roles and keyboard navigation
- Regenerate search index with titles and descriptions

## Testing
- `ruby scripts/generate_search_index.rb`
- `node --check assets/js/search.js`
- `npm install lunr jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f8facbc832e8b43efec7b9d3031