### PR TITLE
Extract chapter styles into standalone CSS files

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,16 @@
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:type" content="website">
   <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
+  {% if page.chapter_css %}
+  <link rel="stylesheet" href="{{ ('/assets/css/chapters/' | append: page.chapter_css) | relative_url }}">
+  {% endif %}
+  {% if page.include_chapter_styles %}
+  {% assign chapters = site.pages | where_exp:"p","p.path contains 'chapter'" | sort:"path" %}
+  {% for chapter in chapters %}
+  {% assign css = chapter.path | replace: '.html','' | split:'/' | last | prepend: '/assets/css/chapters/' | append: '.css' %}
+  <link rel="stylesheet" href="{{ css | relative_url }}">
+  {% endfor %}
+  {% endif %}
 </head>
 <body>
   {% include nav.html %}

--- a/assets/css/chapters/chapter1.css
+++ b/assets/css/chapters/chapter1.css
@@ -1,0 +1,24 @@
+/* Page-specific styles for Chapter I */
+.layout{display:grid;grid-template-columns:2fr 1fr;gap:1.25rem;}
+@media (max-width:900px){.layout{grid-template-columns:1fr;}}
+.card h2{font-size:1.15rem;margin:0 0 .75rem;}
+.card p{margin:.6rem 0;}
+.facts{display:grid;grid-template-columns:1fr 1fr;gap:.4rem .8rem;font-size:.95rem;}
+.facts dt{color:var(--muted);}
+.facts dd{margin:0;font-weight:600;}
+@media (max-width:640px){.facts{grid-template-columns:1fr;}}
+.chips{display:flex;flex-wrap:wrap;gap:.4rem;margin:.5rem 0;}
+.chip{border:1px solid var(--line);padding:.2rem .5rem;border-radius:999px;font-size:.85rem;background:#fff;}
+.chip--danger{background:#fde7e7;border-color:#f3c9c9;color:#680000;}
+.sidebar{position:sticky;top:1rem;align-self:start;}
+.map{margin:0 0 .8rem;}
+.map a{display:block;text-decoration:none;color:inherit;}
+.map img{width:100%;height:auto;display:block;border-radius:.5rem;border:1px solid var(--line);box-shadow:0 1px 4px rgba(0,0,0,.06);}
+.map small{display:block;margin-top:.35rem;color:var(--muted);}
+.toc{list-style:none;margin:0;padding:0;}
+.toc li{margin:.25rem 0;}
+.toc a{text-decoration:none;color:#333;}
+.toc a:hover{text-decoration:underline;}
+.timeline{list-style:none;padding:0;margin:0;}
+.timeline li{padding:.5rem .6rem;border-left:3px solid #e6e6e6;margin:.4rem 0 .4rem .3rem;}
+.timeline time{font-weight:700;color:#4b0000;margin-right:.4rem;}

--- a/assets/css/chapters/chapter2.css
+++ b/assets/css/chapters/chapter2.css
@@ -1,0 +1,18 @@
+.wrap{max-width:1100px;margin:0 auto;padding:1.25rem;}
+main{display:grid;grid-template-columns:1fr 320px;gap:1.25rem;}
+@media (max-width:980px){main{grid-template-columns:1fr;}}
+.card h2,.card h3{margin:.1rem 0 .6rem 0;}
+.kicker{font-size:.9rem;letter-spacing:.05em;text-transform:uppercase;color:#b94c4c;}
+.timeline{border-left:3px solid var(--line);margin-left:.4rem;padding-left:1rem;}
+.event{margin:1rem 0;}
+.event time{font-weight:600;}
+dl{display:grid;grid-template-columns:auto 1fr;gap:.4rem .8rem;margin:.6rem 0;}
+dt{color:var(--muted);}
+dd{margin:0;}
+table{width:100%;border-collapse:collapse;}
+th,td{padding:.5rem;border-bottom:1px solid var(--line);text-align:left;}
+th{background:#faf7f7;}
+.badge{display:inline-block;font-size:.8rem;padding:.1rem .5rem;border:1px solid var(--line);border-radius:999px;}
+.ok{background:#edf7ed;border-color:#cfe7cf;}
+footer{color:var(--muted);font-size:.95rem;padding:2rem 0;}
+code.inline{background:#f3f3f3;border:1px solid #e5e5e5;padding:.05rem .35rem;border-radius:5px;}

--- a/chapter1.html
+++ b/chapter1.html
@@ -2,34 +2,8 @@
 layout: default
 title: Chapter I – The Dawn of Samogitia (1444)
 description: Chronicles Samogitia's dawn in 1444 with key events and early facts.
+chapter_css: chapter1.css
 ---
-
-<style>
-  /* Page-specific styles for Chapter I */
-  .layout{display:grid;grid-template-columns:2fr 1fr;gap:1.25rem;}
-  @media (max-width:900px){.layout{grid-template-columns:1fr;}}
-  .card h2{font-size:1.15rem;margin:0 0 .75rem;}
-  .card p{margin:.6rem 0;}
-  .facts{display:grid;grid-template-columns:1fr 1fr;gap:.4rem .8rem;font-size:.95rem;}
-  .facts dt{color:var(--muted);}
-  .facts dd{margin:0;font-weight:600;}
-  @media (max-width:640px){.facts{grid-template-columns:1fr;}}
-  .chips{display:flex;flex-wrap:wrap;gap:.4rem;margin:.5rem 0;}
-  .chip{border:1px solid var(--line);padding:.2rem .5rem;border-radius:999px;font-size:.85rem;background:#fff;}
-  .chip--danger{background:#fde7e7;border-color:#f3c9c9;color:#680000;}
-  .sidebar{position:sticky;top:1rem;align-self:start;}
-  .map{margin:0 0 .8rem;}
-  .map a{display:block;text-decoration:none;color:inherit;}
-  .map img{width:100%;height:auto;display:block;border-radius:.5rem;border:1px solid var(--line);box-shadow:0 1px 4px rgba(0,0,0,.06);}
-  .map small{display:block;margin-top:.35rem;color:var(--muted);}
-  .toc{list-style:none;margin:0;padding:0;}
-  .toc li{margin:.25rem 0;}
-  .toc a{text-decoration:none;color:#333;}
-  .toc a:hover{text-decoration:underline;}
-  .timeline{list-style:none;padding:0;margin:0;}
-  .timeline li{padding:.5rem .6rem;border-left:3px solid #e6e6e6;margin:.4rem 0 .4rem .3rem;}
-  .timeline time{font-weight:700;color:#4b0000;margin-right:.4rem;}
-</style>
 
 <header class="banner">
   <h1>Chapter I – The Dawn of Samogitia</h1>

--- a/chapter2.html
+++ b/chapter2.html
@@ -2,29 +2,8 @@
 layout: default
 title: "Chapter II — Expansion & The First War (1445–1446) | Chronicle of Samogitia"
 description: "Chapter II details Samogitia’s early expansion and pre-war build-up, including the Iron Wolf and Black Death armies, and succession events in 1446."
+chapter_css: chapter2.css
 ---
-
-<style>
-  .wrap{max-width:1100px;margin:0 auto;padding:1.25rem;}
-  main{display:grid;grid-template-columns:1fr 320px;gap:1.25rem;}
-  @media (max-width:980px){main{grid-template-columns:1fr;}}
-  .card h2,.card h3{margin:.1rem 0 .6rem 0;}
-  .kicker{font-size:.9rem;letter-spacing:.05em;text-transform:uppercase;color:#b94c4c;}
-  .timeline{border-left:3px solid var(--line);margin-left:.4rem;padding-left:1rem;}
-  .event{margin:1rem 0;}
-  .event time{font-weight:600;}
-  dl{display:grid;grid-template-columns:auto 1fr;gap:.4rem .8rem;margin:.6rem 0;}
-  dt{color:var(--muted);}
-  dd{margin:0;}
-  table{width:100%;border-collapse:collapse;}
-  th,td{padding:.5rem;border-bottom:1px solid var(--line);text-align:left;}
-  th{background:#faf7f7;}
-  .badge{display:inline-block;font-size:.8rem;padding:.1rem .5rem;border:1px solid var(--line);border-radius:999px;}
-  .ok{background:#edf7ed;border-color:#cfe7cf;}
-  footer{color:var(--muted);font-size:.95rem;padding:2rem 0;}
-  code.inline{background:#f3f3f3;border:1px solid #e5e5e5;padding:.05rem .35rem;border-radius:5px;}
-</style>
-
   <header class="banner">
     <h1>Chapter II — Expansion & The First War (1445–1446)</h1>
     <p class="muted">From cautious growth to open conflict: armies named and succession secured.</p>

--- a/chronicle.html
+++ b/chronicle.html
@@ -2,6 +2,7 @@
 layout: default
 title: "Full Chronicle"
 description: "All chapters combined in one continuous page."
+include_chapter_styles: true
 ---
 
 <header class="banner">


### PR DESCRIPTION
## Summary
- Move chapter-specific styles from inline `<style>` blocks into `assets/css/chapters` files
- Teach default layout to load per-chapter stylesheets and aggregate them for the full chronicle
- Add front matter hooks for chapter pages and chronicle to reference these stylesheets

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68aaca454a70832eb6df7338ef524fcc